### PR TITLE
Improve test coverage to 92%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Ruby/Smashing dashboard for monitoring home energy consumption. It integrates with:
+- **Grid meter** via Volkszähler (vzlogger) for power consumption/feed-in data
+- **Solar inverter** via OpenDTU for PV production
+- **Heating meter** for heating consumption
+- **InfluxDB** for data export/storage
+- **Tibber GraphQL API** for energy pricing
+
+## Commands
+
+```bash
+# Run tests
+bundle exec ruby -r simplecov -Itest test/unit_test.rb
+
+# Build Docker image
+docker build -t daisaja/energymeter:latest .
+
+# Run locally with Docker
+docker run -p 3030:3030 --env-file .env daisaja/energymeter:latest
+
+# Install dependencies
+bundle install
+
+# Precompile assets
+rake precompile-assets
+```
+
+## Architecture
+
+### Smashing Framework Structure
+- `dashboards/` - ERB templates defining dashboard layouts (power.erb, overview.erb, ops.erb)
+- `widgets/` - Reusable UI components (CoffeeScript, HTML, SCSS)
+- `jobs/` - Scheduled background tasks that fetch data and push to widgets
+
+### Data Flow
+1. **Jobs** (in `jobs/`) run on SCHEDULER intervals (e.g., every 3s)
+2. Jobs fetch data from external sources via **meter clients** (in `jobs/meter_helper/`)
+3. Jobs call `send_event('widget_id', { data })` to push updates to dashboards
+
+### Meter Clients
+Located in `jobs/meter_helper/`:
+- `grid_meter_client.rb` - Fetches grid power data from Volkszähler API (port 8081)
+- `heating_meter_client.rb` - Fetches heating consumption
+- `solar_meter_client.rb` - Fetches SMA inverter data
+- `opendtu_meter_client.rb` - Fetches OpenDTU solar data (API: `/api/livedata/status`)
+
+### Required Environment Variables
+- `GRID_METER_HOST` - Volkszähler host IP
+- `OPENDTU_HOST` - OpenDTU inverter host IP
+- `EM_APP_ID`, `EM_CONSUMER_KEY`, `EM_CONSUMER_SECRET` - Yahoo Weather API credentials
+
+## Testing
+
+Tests use Minitest with WebMock for HTTP stubbing. All external API calls must be mocked.
+
+```ruby
+# Example test pattern
+stub_request(:get, "http://192.168.1.100:80/api/livedata/status")
+  .to_return(status: 200, body: response.to_json)
+```
+
+## Code Style
+
+- Ruby 2-space indentation, snake_case naming
+- Use HTTParty for HTTP requests
+- Wrap external API calls in error handling with fallback values
+- Follow existing Smashing widget conventions

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -1,12 +1,24 @@
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/test/'
+end
+
 require 'minitest/autorun'
 require 'webmock/minitest'
 
 # Set environment variables BEFORE requiring the files that use them
 ENV['GRID_METER_HOST'] = '192.168.178.103'
 ENV['OPENDTU_HOST'] = '192.168.1.100'
+ENV['HEATING_METER_HOST'] = '192.168.178.50'
+ENV['SOLAR_METER_HOST'] = '192.168.178.60'
+ENV['INFLUXDB_HOST'] = '192.168.178.70'
+ENV['INFLUXDB_TOKEN'] = 'test-token'
 
-require_relative '../jobs/meter_helper/grid_meter_client' #name of file with class
+require_relative '../jobs/meter_helper/grid_meter_client'
 require_relative '../jobs/meter_helper/opendtu_meter_client'
+require_relative '../jobs/meter_helper/heating_meter_client'
+require_relative '../jobs/meter_helper/solar_meter_client'
+require_relative '../jobs/influx_exporter'
 
 class UnitTest < Minitest::Test
 
@@ -86,6 +98,145 @@ class UnitTest < Minitest::Test
     assert_equal(0.0, opendtu_measures.power_watts)
     assert_equal(0.0, opendtu_measures.yield_day)
     assert_equal(0.0, opendtu_measures.yield_total)
+  end
+
+  # HeatingMeasurements Tests
+  def test_heating_meter_client
+    current_month = Date.today.month
+
+    # Mock Youless API responses
+    stub_request(:get, "http://192.168.178.50/a?f=j")
+      .to_return(status: 200, body: { 'pwr' => 1500 }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    stub_request(:get, "http://192.168.178.50/V?m=#{current_month}&?f=j")
+      .to_return(status: 200, body: { 'val' => ['10.5', '20.3', '15.2'] }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    stub_request(:get, "http://192.168.178.50/V?d=0&f=j")
+      .to_return(status: 200, body: { 'val' => [500, 600, 400] }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    stub_request(:get, "http://192.168.178.50/V?d=1&f=j")
+      .to_return(status: 200, body: { 'val' => [800, 700, 500] }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    heating_measures = HeatingMeasurements.new()
+    assert_equal(1500, heating_measures.heating_watts_current)
+    assert_in_delta(46.0, heating_measures.heating_per_month, 0.1)  # 10.5 + 20.3 + 15.2 = 46.0
+    assert_equal(1, heating_measures.heating_kwh_current_day)  # (500+600+400)/1000 = 1
+    assert_equal(2, heating_measures.heating_kwh_last_day)  # (800+700+500)/1000 = 2
+  end
+
+  def test_heating_meter_client_error_handling
+    current_month = Date.today.month
+
+    # Mock Youless being unavailable
+    stub_request(:get, "http://192.168.178.50/a?f=j")
+      .to_raise(Errno::ECONNREFUSED)
+
+    stub_request(:get, "http://192.168.178.50/V?m=#{current_month}&?f=j")
+      .to_raise(Errno::ECONNREFUSED)
+
+    stub_request(:get, "http://192.168.178.50/V?d=0&f=j")
+      .to_raise(Errno::ECONNREFUSED)
+
+    stub_request(:get, "http://192.168.178.50/V?d=1&f=j")
+      .to_raise(Errno::ECONNREFUSED)
+
+    assert_raises(Errno::ECONNREFUSED) do
+      HeatingMeasurements.new()
+    end
+  end
+
+  # SolarMeasurements Tests
+  def test_solar_meter_client
+    sma_response = {
+      'result' => {
+        '017A-B339126F' => {
+          '6100_40263F00' => {
+            '1' => [{ 'val' => 3500 }]
+          }
+        }
+      }
+    }
+
+    stub_request(:post, "https://192.168.178.60/dyn/getDashValues.json")
+      .to_return(status: 200, body: sma_response.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    solar_measures = SolarMeasurements.new()
+    assert_equal(3500, solar_measures.solar_watts_current)
+    assert_equal(0.0, solar_measures.solar_watts_per_month)  # not implemented
+  end
+
+  def test_solar_meter_client_fallback_device_id
+    sma_response = {
+      'result' => {
+        '017A-xxxxx26F' => {
+          '6100_40263F00' => {
+            '1' => [{ 'val' => 2800 }]
+          }
+        }
+      }
+    }
+
+    stub_request(:post, "https://192.168.178.60/dyn/getDashValues.json")
+      .to_return(status: 200, body: sma_response.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    solar_measures = SolarMeasurements.new()
+    assert_equal(2800, solar_measures.solar_watts_current)
+  end
+
+  def test_solar_meter_client_error_handling
+    # SolarMeasurements hat keine Fehlerbehandlung für HTTP-Fehler
+    stub_request(:post, "https://192.168.178.60/dyn/getDashValues.json")
+      .to_raise(Errno::ECONNREFUSED)
+
+    assert_raises(Errno::ECONNREFUSED) do
+      SolarMeasurements.new()
+    end
+  end
+
+  def test_solar_meter_client_nil_value
+    sma_response = {
+      'result' => {
+        '017A-B339126F' => {
+          '6100_40263F00' => {
+            '1' => [{ 'val' => nil }]
+          }
+        }
+      }
+    }
+
+    stub_request(:post, "https://192.168.178.60/dyn/getDashValues.json")
+      .to_return(status: 200, body: sma_response.to_json, headers: { 'Content-Type' => 'application/json' })
+
+    solar_measures = SolarMeasurements.new()
+    assert_equal(0.0, solar_measures.solar_watts_current)
+  end
+
+  # InfluxExporter Tests
+  def test_influx_exporter_initialization
+    exporter = InfluxExporter.new()
+    assert_instance_of(InfluxDB2::Client, exporter.influx_client)
+  end
+
+  # is_new_day() Helper Tests
+  def test_is_new_day_at_midnight
+    # Stub Time.now to return a time just after midnight
+    Time.stub :now, Time.new(2024, 1, 15, 0, 5, 0) do
+      assert_equal(true, is_new_day())
+    end
+  end
+
+  def test_is_new_day_during_day
+    # Stub Time.now to return midday
+    Time.stub :now, Time.new(2024, 1, 15, 12, 0, 0) do
+      assert_equal(false, is_new_day())
+    end
+  end
+
+  def test_is_new_day_after_window
+    # Stub Time.now to return 11 minutes after midnight (outside 600s window)
+    Time.stub :now, Time.new(2024, 1, 15, 0, 11, 0) do
+      assert_equal(false, is_new_day())
+    end
   end
 
 end

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -1,11 +1,3 @@
-require 'simplecov'
-SimpleCov.start do
-  add_filter '/test/'
-end
-
-require 'minitest/autorun'
-require 'webmock/minitest'
-
 # Set environment variables BEFORE requiring the files that use them
 ENV['GRID_METER_HOST'] = '192.168.178.103'
 ENV['OPENDTU_HOST'] = '192.168.1.100'
@@ -14,6 +6,13 @@ ENV['SOLAR_METER_HOST'] = '192.168.178.60'
 ENV['INFLUXDB_HOST'] = '192.168.178.70'
 ENV['INFLUXDB_TOKEN'] = 'test-token'
 
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/test/'
+end
+
+require 'minitest/autorun'
+require 'webmock/minitest'
 require_relative '../jobs/meter_helper/grid_meter_client'
 require_relative '../jobs/meter_helper/opendtu_meter_client'
 require_relative '../jobs/meter_helper/heating_meter_client'


### PR DESCRIPTION
## Summary
- Add 10 new tests for previously untested meter clients (HeatingMeasurements, SolarMeasurements, InfluxExporter)
- Add tests for `is_new_day()` helper function with time stubbing
- Configure SimpleCov for coverage reporting
- Increase test coverage from 3 tests to 13 tests (92.44% line coverage)

## Test plan
- [ ] Verify all 13 tests pass: `bundle exec ruby -Itest test/unit_test.rb`
- [ ] Check coverage report in `coverage/index.html`
- [ ] Confirm CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)