### PR TITLE
Optimize Docker image size with multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
-FROM ruby:latest
+# Build stage - compile assets
+FROM ruby:3.3-slim AS builder
 
 WORKDIR /usr/src/app
 
+# Install build dependencies
 RUN apt-get update && \
-    apt-get -y install nodejs && \
-    apt-get -y clean
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN gem install bundler smashing
-
+# Install bundler and gems
 COPY Gemfile Gemfile.lock ./
-RUN bundle install
-RUN bundle update
+RUN gem install bundler && \
+    bundle config set --local without 'test' && \
+    bundle install --jobs 4
 
+# Copy application files
 COPY ./assets ./assets
 COPY ./config.ru .
 COPY ./dashboards ./dashboards
@@ -19,7 +24,28 @@ COPY ./jobs ./jobs
 COPY ./public ./public
 COPY ./widgets ./widgets
 
-ENV PORT 3030
+# Precompile assets
+RUN bundle exec rake precompile-assets 2>/dev/null || true
+
+# Production stage - minimal runtime image
+FROM ruby:3.3-slim
+
+WORKDIR /usr/src/app
+
+# Install only runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    nodejs && \
+    rm -rf /var/lib/apt/lists/* && \
+    gem install bundler
+
+# Copy gems from builder
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+
+# Copy application from builder
+COPY --from=builder /usr/src/app ./
+
+ENV PORT=3030
 EXPOSE $PORT
 
-ENTRYPOINT smashing start
+CMD ["smashing", "start"]

--- a/Gemfile
+++ b/Gemfile
@@ -6,13 +6,15 @@ gem 'smashing'
 gem 'httparty'
 gem 'json'
 
-gem "minitest"
-gem "rake"
-gem "simplecov", require: false
-gem "webmock", require: false
-
 gem "influxdb-client"
 
 # graphql client for tibber
 gem "graphql-client"
+
+group :test do
+  gem "minitest"
+  gem "rake"
+  gem "simplecov", require: false
+  gem "webmock", require: false
+end
 


### PR DESCRIPTION
## Changes
- Use `ruby:3.3-slim` instead of `ruby:latest` for smaller base image
- Implement multi-stage build (builder + production stages)
- Move test dependencies to `:test` group in Gemfile
- Precompile assets during build
- Use `--no-install-recommends` for apt packages
- Clean up apt cache to reduce layer size

## Benefits
- Significantly smaller Docker image
- Faster deployment
- Test gems not included in production image