### PR TITLE
Redesign weather widget with Klimato-style layout

### DIFF
--- a/jobs/weather.rb
+++ b/jobs/weather.rb
@@ -9,7 +9,14 @@ class WeatherClient
 
   OPEN_METEO_URL = "https://api.open-meteo.com/v1/forecast"
 
-  attr_reader :temperature, :weather_code, :wind_speed, :weather_description, :weather_icon
+  attr_reader :temperature, :weather_code, :wind_speed, :weather_description, :weather_icon, :climacon_code,
+              :forecast1, :forecast1_climacon, :forecast1_day,
+              :forecast2, :forecast2_climacon, :forecast2_day
+
+  GERMAN_WEEK_DAYS = {
+    'Monday' => 'Montag', 'Tuesday' => 'Dienstag', 'Wednesday' => 'Mittwoch',
+    'Thursday' => 'Donnerstag', 'Friday' => 'Freitag', 'Saturday' => 'Samstag', 'Sunday' => 'Sonntag'
+  }
 
   def initialize
     fetch_weather_data
@@ -20,14 +27,29 @@ class WeatherClient
       latitude: LATITUDE,
       longitude: LONGITUDE,
       current: 'temperature_2m,weather_code,wind_speed_10m',
+      daily: 'weather_code,temperature_2m_max,temperature_2m_min',
+      forecast_days: 3,
       timezone: 'Europe/Berlin'
     })
 
-    current = response.parsed_response['current']
+    data = response.parsed_response
+    current = data['current']
     @temperature = current['temperature_2m'].round(1)
     @weather_code = current['weather_code']
     @wind_speed = current['wind_speed_10m'].round(1)
     @weather_description, @weather_icon = weather_code_to_description(@weather_code)
+    @climacon_code = weather_code_to_climacon(@weather_code)
+
+    # Forecast für morgen und übermorgen (Index 1 und 2, Index 0 ist heute)
+    daily = data['daily']
+    @forecast1 = "#{daily['temperature_2m_min'][1].round}° - #{daily['temperature_2m_max'][1].round}°"
+    @forecast1_climacon = weather_code_to_climacon(daily['weather_code'][1])
+    @forecast1_day = german_weekday(daily['time'][1])
+
+    @forecast2 = "#{daily['temperature_2m_min'][2].round}° - #{daily['temperature_2m_max'][2].round}°"
+    @forecast2_climacon = weather_code_to_climacon(daily['weather_code'][2])
+    @forecast2_day = german_weekday(daily['time'][2])
+
     save_values
   rescue Errno::EHOSTUNREACH, Errno::ECONNREFUSED => e
     puts "[Weather] Verbindung zu Open-Meteo API fehlgeschlagen: Server nicht erreichbar"
@@ -43,7 +65,14 @@ class WeatherClient
       weather_code: @weather_code,
       wind_speed: @wind_speed,
       weather_description: @weather_description,
-      weather_icon: @weather_icon
+      weather_icon: @weather_icon,
+      climacon_code: @climacon_code,
+      forecast1: @forecast1,
+      forecast1_climacon: @forecast1_climacon,
+      forecast1_day: @forecast1_day,
+      forecast2: @forecast2,
+      forecast2_climacon: @forecast2_climacon,
+      forecast2_day: @forecast2_day
     }
   end
 
@@ -53,6 +82,18 @@ class WeatherClient
     @wind_speed = @@last_values[:wind_speed] || 0.0
     @weather_description = @@last_values[:weather_description] || 'Keine Daten'
     @weather_icon = @@last_values[:weather_icon] || '?'
+    @climacon_code = @@last_values[:climacon_code] || 32
+    @forecast1 = @@last_values[:forecast1] || '-'
+    @forecast1_climacon = @@last_values[:forecast1_climacon] || 32
+    @forecast1_day = @@last_values[:forecast1_day] || '-'
+    @forecast2 = @@last_values[:forecast2] || '-'
+    @forecast2_climacon = @@last_values[:forecast2_climacon] || 32
+    @forecast2_day = @@last_values[:forecast2_day] || '-'
+  end
+
+  def german_weekday(date_string)
+    date = Date.parse(date_string)
+    GERMAN_WEEK_DAYS[date.strftime('%A')]
   end
 
   def weather_code_to_description(code)
@@ -72,6 +113,24 @@ class WeatherClient
     else ['Unbekannt', '?']
     end
   end
+
+  def weather_code_to_climacon(code)
+    case code
+    when 0 then 32                # Klar -> Sonne
+    when 1, 2, 3 then 26          # Teilweise bewölkt -> Wolke mit Sonne
+    when 45, 48 then 20           # Nebel
+    when 51, 53, 55 then 9        # Nieselregen
+    when 61, 63, 65 then 12       # Regen
+    when 66, 67 then 18           # Gefrierender Regen
+    when 71, 73, 75 then 16       # Schnee
+    when 77 then 17               # Schneekörner
+    when 80, 81, 82 then 11       # Regenschauer
+    when 85, 86 then 16           # Schneeschauer
+    when 95 then 6                # Gewitter
+    when 96, 99 then 6            # Gewitter mit Hagel
+    else 32                       # Fallback: Sonne
+    end
+  end
 end
 
 if defined?(SCHEDULER)
@@ -81,7 +140,14 @@ if defined?(SCHEDULER)
     send_event('weather_temperature', {
       current: weather.temperature,
       icon: weather.weather_icon,
-      moreinfo: "#{weather.weather_description}, Wind: #{weather.wind_speed} km/h"
+      climacon_code: weather.climacon_code,
+      moreinfo: "#{weather.weather_description}, Wind: #{weather.wind_speed} km/h",
+      forecast1: weather.forecast1,
+      forecast1_climacon: weather.forecast1_climacon,
+      forecast1_day: weather.forecast1_day,
+      forecast2: weather.forecast2,
+      forecast2_climacon: weather.forecast2_climacon,
+      forecast2_day: weather.forecast2_day
     })
   end
 end

--- a/widgets/weather/weather.coffee
+++ b/widgets/weather/weather.coffee
@@ -1,6 +1,25 @@
 class Dashing.Weather extends Dashing.Widget
-  ready: ->
-    # Widget is ready
 
   onData: (data) ->
-    # Called when new data arrives
+    @setBackgroundClassBy parseInt(data.current, 10)
+
+  setBackgroundClassBy: (temperature) ->
+    @removeBackgroundClass()
+    colorLevel = @findColorLevelBy temperature
+    $(@node).addClass "weather-temperature-#{colorLevel}"
+
+  removeBackgroundClass: ->
+    classNames = $(@node).attr("class").split " "
+    for className in classNames
+      match = /weather-temperature-(.*)/.exec className
+      $(@node).removeClass match[0] if match
+
+  findColorLevelBy: (temperature) ->
+    switch
+      when temperature <= 0 then 0
+      when temperature in [1..5] then 1
+      when temperature in [6..10] then 2
+      when temperature in [11..15] then 3
+      when temperature in [16..20] then 4
+      when temperature in [21..25] then 5
+      when temperature > 25 then 6

--- a/widgets/weather/weather.html
+++ b/widgets/weather/weather.html
@@ -1,10 +1,23 @@
-<h1 class="title" data-bind="title">Wetter</h1>
-
-<div class="weather-content">
-  <span class="weather-icon" data-bind="icon"></span>
-  <span class="weather-temp" data-bind="current | append suffix"></span>
-</div>
-
-<p class="more-info" data-bind="moreinfo"></p>
+<table>
+  <tr>
+    <td colspan="2">
+      <h1 data-bind="current"></h1>
+      <h2 data-bind-class="climacon_code | prepend 'climacon-'"></h2>
+      <h3>Heute</h3>
+    </td>
+  </tr>
+  <tr>
+    <td class="forecast top center">
+      <h2 data-bind-class="forecast1_climacon | prepend 'climacon-'"></h2>
+      <p data-bind="forecast1"></p>
+      <h3 data-bind="forecast1_day"></h3>
+    </td>
+    <td class="forecast top">
+      <h2 data-bind-class="forecast2_climacon | prepend 'climacon-'"></h2>
+      <p data-bind="forecast2"></p>
+      <h3 data-bind="forecast2_day"></h3>
+    </td>
+  </tr>
+</table>
 
 <p class="updated-at" data-bind="updatedAtMessage"></p>

--- a/widgets/weather/weather.scss
+++ b/widgets/weather/weather.scss
@@ -1,35 +1,92 @@
-$background-color: #666666;
+$background-color: darkturquoise;
 
 .widget-weather {
   background-color: $background-color;
+  transition: background-color 2s linear;
+  -moz-transition: background-color 2s linear;
+  -o-transition: background-color 2s linear;
+  -webkit-transition: background-color 2s linear;
 
-  .title {
-    color: rgba(255, 255, 255, 0.7);
+  table {
+    width: 100%;
+    border-collapse: collapse;
   }
 
-  .weather-content {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 15px;
+  h1 {
+    display: inline-block;
+    vertical-align: top;
+    font-size: 80px;
+    &:after {
+      content: "\00b0";
+    }
   }
 
-  .weather-icon {
-    font-size: 50px;
-    line-height: 1;
+  h2 {
+    display: inline-block;
+    vertical-align: bottom;
+    font-size: 100px;
+    font-family: "Climacons-Font";
   }
 
-  .weather-temp {
-    font-size: 45px;
-    font-weight: bold;
+  h3 {
+    width: 100%;
+    text-transform: uppercase;
+    font-size: 15px;
+    letter-spacing: 2px;
   }
 
-  .more-info {
-    color: rgba(255, 255, 255, 0.7);
-    font-size: 14px;
+  .forecast {
+    h2 {
+      font-size: 60px;
+      display: block;
+    }
+
+    p {
+      font-size: 18px;
+      margin: 5px 0;
+    }
+  }
+
+  .top {
+    width: 50%;
+    border-top: 2px solid rgba(255, 255, 255, 0.5);
+    padding-top: 10px;
+  }
+
+  .center {
+    border-right: 2px solid rgba(255, 255, 255, 0.5);
   }
 
   .updated-at {
-    color: rgba(255, 255, 255, 0.5);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 10px;
+    color: lighten($background-color, 15%);
+  }
+}
+
+// Temperature-based background colors
+$background-colors: #52a5ff, #48efff, #4dff5a, #ffe33d, #ff9d37, #ff5131, #ff2c59;
+
+@mixin weather-background($color, $percentage: 25%) {
+  background-color: $color;
+
+  .updated-at {
+    color: lighten($color, $percentage);
+  }
+}
+
+@for $index from 0 through 6 {
+  .widget-weather.weather-temperature-#{$index} {
+    @include weather-background(nth($background-colors, $index + 1));
+  }
+}
+
+// Climacons icon mapping
+$climacons: "\e037", "\e009", "\e009", "\e025", "\e025", "\e00f", "\e015", "\e00f", "\e00c", "\e00c", "\e00f", "\e006", "\e006", "\e015", "\e018", "\e018", "\e018", "\e012", "\e00f", "\e01e", "\e01b", "\e01e", "\e01e", "\e01e", "\e021", "\e01b", "\e000", "\e002", "\e001", "\e002", "\e001", "\e02d", "\e028", "\e001", "\e002", "\e012", "\e028", "\e025", "\e025", "\e025", "\e006", "\e036", "\e036", "\e036", "\e000", "\e025", "\e036", "\e025";
+
+@for $index from 0 through 47 {
+  .climacon-#{$index}:before {
+    content: nth($climacons, $index + 1);
   }
 }


### PR DESCRIPTION
## Summary
- Redesign weather widget to match the original Klimato widget style
- Add Climacons font icons instead of Unicode symbols (80px temp, 100px icon)
- Implement temperature-based background colors with smooth CSS transitions
- Add 2-day weather forecast from Open-Meteo API with German weekday names
- Use table layout with forecast section like original Klimato widget

## Test plan
- [ ] Verify widget displays current temperature with Climacon icon
- [ ] Verify background color changes based on temperature (blue for cold, red for hot)
- [ ] Verify 2-day forecast shows correct weekday names in German
- [ ] Run unit tests: `bundle exec ruby -Itest test/unit_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)