### PR TITLE
Darken weather widget temperature background colors

### DIFF
--- a/widgets/weather/weather.scss
+++ b/widgets/weather/weather.scss
@@ -65,8 +65,8 @@ $background-color: darkturquoise;
   }
 }
 
-// Temperature-based background colors
-$background-colors: #52a5ff, #48efff, #4dff5a, #ffe33d, #ff9d37, #ff5131, #ff2c59;
+// Temperature-based background colors (darkened for better contrast)
+$background-colors: #2a5a8f, #26808f, #289030, #8f7d20, #8f571c, #8f2c1a, #8f1830;
 
 @mixin weather-background($color, $percentage: 25%) {
   background-color: $color;


### PR DESCRIPTION
## Summary
- Darken temperature-based background colors in weather widget for better contrast
- Color scheme inspired by P2 dashboard palette

## Test plan
- [ ] Verify weather widget displays with new darker background colors
- [ ] Check contrast is improved for white text readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)