### PR TITLE
Add Tesla Powerwall integration with dedicated dashboard

### DIFF
--- a/dashboards/p2.erb
+++ b/dashboards/p2.erb
@@ -24,5 +24,6 @@
     <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
       <div data-id="weather_temperature" data-view="Weather" data-title="Wetter Rathenow" data-suffix="°C"></div>
     </li>
+
   </ul>
 </div>

--- a/dashboards/teslawall.erb
+++ b/dashboards/teslawall.erb
@@ -1,0 +1,13 @@
+<div class="gridster">
+  <ul>
+    <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+      <div data-id="powerwall_soc" data-view="Meter" data-title="Powerwall %" data-moreinfo="Ladestand in %" data-min="0" data-max="100" style="background-color:#0a7cc0;"></div>
+    </li>
+    <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+      <div data-id="powerwall_stored" data-view="Number" data-title="Gespeicherte kWh" data-moreinfo="Ladestand in kWh" style="background-color:#085c8f;"></div>
+    </li>
+    <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+      <div data-id="powerwall_power" data-view="Number" data-title="Powerwall Leistung" data-moreinfo="+ laden / - entladen in W" style="background-color:#063f63;"></div>
+    </li>
+  </ul>
+</div>

--- a/jobs/meter_helper/powerwall_client.rb
+++ b/jobs/meter_helper/powerwall_client.rb
@@ -1,0 +1,84 @@
+require 'httparty'
+require 'json'
+
+class PowerwallClient
+  @@auth_token = nil
+  @@last_values = {}
+
+  attr_reader :soc_percent, :power_watts, :stored_kwh
+
+  def initialize
+    @host = ENV['POWERWALL_HOST']
+    @base_url = "https://#{@host}"
+    fetch_data
+  end
+
+  def fetch_data
+    login unless @@auth_token
+    fetch_metrics
+  rescue Errno::EHOSTUNREACH, Errno::ECONNREFUSED => e
+    puts "[Powerwall] Verbindung zu #{@host} fehlgeschlagen: Gerät nicht erreichbar"
+    restore_last_values
+  rescue => e
+    puts "[Powerwall] Fehler: #{e.message}"
+    restore_last_values
+  end
+
+  def to_s
+    super + " soc_percent: #{soc_percent} power_watts: #{power_watts} stored_kwh: #{stored_kwh}"
+  end
+
+  private
+
+  def login
+    response = HTTParty.post(
+      "#{@base_url}/api/login/Basic",
+      body: { username: 'customer', password: ENV['POWERWALL_PASSWORD'],
+              email: ENV['POWERWALL_EMAIL'], force_sm_off: false }.to_json,
+      headers: { 'Content-Type' => 'application/json' },
+      verify: false
+    )
+    @@auth_token = response.parsed_response['token']
+    raise "Login fehlgeschlagen (HTTP #{response.code})" unless @@auth_token
+  end
+
+  def authenticated_get(path)
+    response = HTTParty.get("#{@base_url}#{path}", headers: auth_headers, verify: false)
+    if response.code == 401
+      @@auth_token = nil
+      login
+      response = HTTParty.get("#{@base_url}#{path}", headers: auth_headers, verify: false)
+    end
+    response
+  end
+
+  def auth_headers
+    { 'Cookie' => "AuthCookie=#{@@auth_token}" }
+  end
+
+  def fetch_metrics
+    soe      = authenticated_get('/api/system_status/soe')
+    meters   = authenticated_get('/api/meters/aggregates')
+    status   = authenticated_get('/api/system_status')
+
+    @soc_percent = soe.parsed_response['percentage'].to_f.round(1)
+    # API: positive instant_power = discharging; invert so positive = charging (Laden)
+    @power_watts = (-meters.parsed_response['battery']['instant_power'].to_f).round(0)
+    @stored_kwh  = (status.parsed_response['nominal_energy_remaining'].to_f / 1000.0).round(1)
+    save_values
+  end
+
+  def save_values
+    @@last_values = {
+      soc_percent: @soc_percent,
+      power_watts: @power_watts,
+      stored_kwh:  @stored_kwh
+    }
+  end
+
+  def restore_last_values
+    @soc_percent = @@last_values[:soc_percent] || 0.0
+    @power_watts = @@last_values[:power_watts] || 0.0
+    @stored_kwh  = @@last_values[:stored_kwh]  || 0.0
+  end
+end

--- a/jobs/powerwall.rb
+++ b/jobs/powerwall.rb
@@ -1,0 +1,9 @@
+require_relative 'meter_helper/powerwall_client'
+
+SCHEDULER.every '5s', :first_in => 0 do |job|
+  client = PowerwallClient.new
+
+  send_event('powerwall_soc',    { value: client.soc_percent })
+  send_event('powerwall_power',  { current: client.power_watts })
+  send_event('powerwall_stored', { current: client.stored_kwh })
+end

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -13,9 +13,13 @@ ENV['HEATING_METER_HOST'] = '192.168.178.50'
 ENV['SOLAR_METER_HOST'] = '192.168.178.60'
 ENV['INFLUXDB_HOST'] = '192.168.178.70'
 ENV['INFLUXDB_TOKEN'] = 'test-token'
+ENV['POWERWALL_HOST'] = '192.168.178.200'
+ENV['POWERWALL_EMAIL'] = 'test@example.com'
+ENV['POWERWALL_PASSWORD'] = 'testpassword'
 
 require_relative '../jobs/meter_helper/grid_meter_client'
 require_relative '../jobs/meter_helper/opendtu_meter_client'
+require_relative '../jobs/meter_helper/powerwall_client'
 require_relative '../jobs/meter_helper/heating_meter_client'
 require_relative '../jobs/meter_helper/solar_meter_client'
 require_relative '../jobs/meter_helper/state_manager'
@@ -658,5 +662,127 @@ class StateManagerTest < Minitest::Test
     result = StateManager.load
     refute_nil result['saved_at']
     assert_match(/^\d{4}-\d{2}-\d{2}T/, result['saved_at'])
+  end
+end
+
+class PowerwallClientTest < Minitest::Test
+  POWERWALL_HOST = '192.168.178.200'
+  POWERWALL_LOGIN_URL  = "https://#{POWERWALL_HOST}/api/login/Basic"
+  POWERWALL_SOE_URL    = "https://#{POWERWALL_HOST}/api/system_status/soe"
+  POWERWALL_METERS_URL = "https://#{POWERWALL_HOST}/api/meters/aggregates"
+  POWERWALL_STATUS_URL = "https://#{POWERWALL_HOST}/api/system_status"
+  CONTENT_TYPE_JSON    = 'Content-Type'
+  APPLICATION_JSON     = 'application/json'
+
+  def setup
+    WebMock.disable_net_connect!
+    PowerwallClient.class_variable_set(:@@auth_token, nil)
+    PowerwallClient.class_variable_set(:@@last_values, {})
+  end
+
+  def stub_login
+    stub_request(:post, POWERWALL_LOGIN_URL)
+      .to_return(status: 200,
+                 body: { 'token' => 'testtoken123' }.to_json,
+                 headers: { CONTENT_TYPE_JSON => APPLICATION_JSON })
+  end
+
+  def stub_metrics(soc: 75.5, instant_power: -1200.0, energy_remaining: 10200)
+    stub_request(:get, POWERWALL_SOE_URL)
+      .to_return(status: 200,
+                 body: { 'percentage' => soc }.to_json,
+                 headers: { CONTENT_TYPE_JSON => APPLICATION_JSON })
+    stub_request(:get, POWERWALL_METERS_URL)
+      .to_return(status: 200,
+                 body: { 'battery' => { 'instant_power' => instant_power } }.to_json,
+                 headers: { CONTENT_TYPE_JSON => APPLICATION_JSON })
+    stub_request(:get, POWERWALL_STATUS_URL)
+      .to_return(status: 200,
+                 body: { 'nominal_energy_remaining' => energy_remaining }.to_json,
+                 headers: { CONTENT_TYPE_JSON => APPLICATION_JSON })
+  end
+
+  def test_powerwall_client_basic_values
+    stub_login
+    stub_metrics
+
+    client = PowerwallClient.new
+    assert_equal(75.5,  client.soc_percent)
+    assert_equal(1200.0, client.power_watts)   # API -1200 (charging) → inverted → +1200
+    assert_equal(10.2,  client.stored_kwh)     # 10200 Wh / 1000
+  end
+
+  def test_powerwall_client_discharging_inverts_sign
+    stub_login
+    stub_metrics(instant_power: 800.0)  # positive API = discharging
+
+    client = PowerwallClient.new
+    assert_equal(-800.0, client.power_watts)   # inverted → -800 (Entladen)
+  end
+
+  def test_powerwall_client_token_cached_across_instances
+    stub_login
+    stub_metrics
+
+    PowerwallClient.new
+    PowerwallClient.new  # second instance should NOT call login again
+
+    assert_requested(:post, POWERWALL_LOGIN_URL, times: 1)
+  end
+
+  def test_powerwall_client_retries_login_on_401
+    stub_login
+    stub_request(:get, POWERWALL_SOE_URL)
+      .to_return(status: 401, body: '').then
+      .to_return(status: 200,
+                 body: { 'percentage' => 50.0 }.to_json,
+                 headers: { CONTENT_TYPE_JSON => APPLICATION_JSON })
+    stub_metrics(soc: 50.0)
+
+    # Need a second login stub for retry
+    stub_request(:post, POWERWALL_LOGIN_URL)
+      .to_return(status: 200,
+                 body: { 'token' => 'newtoken456' }.to_json,
+                 headers: { CONTENT_TYPE_JSON => APPLICATION_JSON })
+
+    client = PowerwallClient.new
+    assert_equal(50.0, client.soc_percent)
+  end
+
+  def test_powerwall_client_connection_refused_returns_defaults
+    stub_request(:post, POWERWALL_LOGIN_URL).to_raise(Errno::ECONNREFUSED)
+
+    client = PowerwallClient.new
+    assert_equal(0.0, client.soc_percent)
+    assert_equal(0.0, client.power_watts)
+    assert_equal(0.0, client.stored_kwh)
+  end
+
+  def test_powerwall_client_host_unreachable_returns_defaults
+    stub_request(:post, POWERWALL_LOGIN_URL).to_raise(Errno::EHOSTUNREACH)
+
+    client = PowerwallClient.new
+    assert_equal(0.0, client.soc_percent)
+    assert_equal(0.0, client.power_watts)
+    assert_equal(0.0, client.stored_kwh)
+  end
+
+  def test_powerwall_client_keeps_last_values_on_error
+    stub_login
+    stub_metrics
+
+    client = PowerwallClient.new
+    assert_equal(75.5, client.soc_percent)
+
+    # Second request fails – token is cached, so failure happens in fetch_metrics
+    WebMock.reset!
+    stub_request(:get, POWERWALL_SOE_URL).to_raise(Errno::ECONNREFUSED)
+    stub_request(:get, POWERWALL_METERS_URL).to_raise(Errno::ECONNREFUSED)
+    stub_request(:get, POWERWALL_STATUS_URL).to_raise(Errno::ECONNREFUSED)
+
+    client2 = PowerwallClient.new
+    assert_equal(75.5,  client2.soc_percent)
+    assert_equal(1200.0, client2.power_watts)
+    assert_equal(10.2,  client2.stored_kwh)
   end
 end


### PR DESCRIPTION
## Summary

- New `PowerwallClient` fetches SOC %, stored kWh and instant power (±W) from the local Powerwall Gateway HTTPS API with token auth and automatic 401-retry
- New `jobs/powerwall.rb` job polling every 5s
- New `dashboards/teslawall.erb` with 3 widgets: SOC gauge (Meter), stored energy (Number), charge/discharge power (Number)
- Powerwall widgets intentionally kept on a separate dashboard (`/teslawall`) instead of `p2.erb`

## Configuration

Three new environment variables required in `.env`:
```
POWERWALL_HOST=<gateway-ip>
POWERWALL_EMAIL=<tesla-account-email>
POWERWALL_PASSWORD=<password>
```

## Test plan

- [x] 7 new `PowerwallClientTest` tests pass (`bundle exec ruby -r simplecov -Itest test/unit_test.rb`)
- [x] Dashboard visible at `http://<host>:3030/teslawall` after deploy
- [x] SOC gauge, stored kWh and ±W power update every 5s with live data