### PR TITLE
Include Powerwall battery discharge in Verbrauch widget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,10 @@ stub_request(:get, "http://192.168.1.100:80/api/livedata/status")
 
 ## Git Workflow
 
+Before starting any new feature or bugfix:
+1. `git checkout master && git pull`
+2. `git checkout -b feature/<name>` (always work on a feature branch, never directly on master)
+
 After creating and merging a PR, always:
-1. `git checkout master`
-2. `git pull`
-3. `git branch -d <feature-branch>` (delete the local feature branch)
+1. `git checkout master && git pull`
+2. `git branch -d <feature-branch>` (delete the local feature branch)

--- a/jobs/grid_watts.rb
+++ b/jobs/grid_watts.rb
@@ -1,25 +1,28 @@
 require_relative 'meter_helper/grid_meter_client'
 require_relative 'meter_helper/solar_meter_client'
 
-# :first_in sets how long it takes before the job is first run. In this case, it is run immediately
-SCHEDULER.every '2s', :first_in => 0 do |job|
-  grid_measurements = GridMeasurements.new()
-  solar_measurements = SolarMeasurements.new()
+if defined?(SCHEDULER)
+  SCHEDULER.every '2s', :first_in => 0 do |job|
+    grid_measurements = GridMeasurements.new()
+    solar_measurements = SolarMeasurements.new()
 
-  grid_supply_current = (grid_measurements.grid_supply_current * 1000).round(0)
-  grid_feed_current = (grid_measurements.grid_feed_current * 1000).round(0)
+    grid_supply_current = (grid_measurements.grid_supply_current * 1000).round(0)
+    grid_feed_current = (grid_measurements.grid_feed_current * 1000).round(0)
 
-  solar_watts_current = solar_measurements.solar_watts_current
-  current_consumption = current_consumption(solar_watts_current, grid_supply_current, grid_feed_current)
+    solar_watts_current = solar_measurements.solar_watts_current
+    battery_power = defined?($powerwall_battery_power) ? $powerwall_battery_power.to_f : 0.0
+    house_consumption = current_consumption(solar_watts_current, grid_supply_current, grid_feed_current, battery_power)
 
-  send_event('wattmeter_grid_supply', { value: grid_supply_current })
-  send_event('wattmeter_grid_feed', { value: grid_feed_current })
-  send_event('wattmeter_house_power_consumption',   { value: current_consumption })
-  report_grid(grid_supply_current, grid_feed_current, current_consumption)
+    send_event('wattmeter_grid_supply', { value: grid_supply_current })
+    send_event('wattmeter_grid_feed', { value: grid_feed_current })
+    send_event('wattmeter_house_power_consumption', { value: house_consumption })
+    report_grid(grid_supply_current, grid_feed_current, house_consumption)
+  end
 end
 
-def current_consumption(solar_production, grid_supply, grid_feed)
-  return solar_production + grid_supply - grid_feed
+def current_consumption(solar_production, grid_supply, grid_feed, battery_power = 0.0)
+  battery_discharge = [-battery_power, 0].max
+  return solar_production + grid_supply - grid_feed + battery_discharge
 end
 
 def report_grid(grid_supply_current, grid_feed_current, current_consumption)

--- a/jobs/powerwall.rb
+++ b/jobs/powerwall.rb
@@ -1,7 +1,11 @@
 require_relative 'meter_helper/powerwall_client'
 
+$powerwall_battery_power = 0.0
+
 SCHEDULER.every '5s', :first_in => 0 do |job|
   client = PowerwallClient.new
+
+  $powerwall_battery_power = client.power_watts
 
   send_event('powerwall_soc',    { value: client.soc_percent })
   send_event('powerwall_power',  { current: client.power_watts })

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -25,6 +25,7 @@ require_relative '../jobs/meter_helper/solar_meter_client'
 require_relative '../jobs/meter_helper/state_manager'
 require_relative '../jobs/weather'
 require_relative '../jobs/influx_exporter'
+require_relative '../jobs/grid_watts'
 
 class UnitTest < Minitest::Test
   # Test constants to avoid duplication
@@ -662,6 +663,41 @@ class StateManagerTest < Minitest::Test
     result = StateManager.load
     refute_nil result['saved_at']
     assert_match(/^\d{4}-\d{2}-\d{2}T/, result['saved_at'])
+  end
+end
+
+class GridWattsTest < Minitest::Test
+  # Vorzeichen-Konvention (PowerwallClient): positiv = Laden, negativ = Entladen
+  # Gesamtlast = Solar + Netzbezug - Einspeisung + Batterie-Entladung
+  # Batterie-Laden ist im Zähler bereits sichtbar (keine Extra-Korrektur nötig).
+  # Batterie-Entladen ist für den Zähler unsichtbar → muss addiert werden.
+
+  def test_current_consumption_without_battery
+    # Solar: 3000W, Bezug: 500W, keine Einspeisung, keine Batterie
+    assert_equal(3500, current_consumption(3000, 500, 0, 0))
+  end
+
+  def test_current_consumption_with_feed_no_battery
+    # Solar: 3000W, kein Bezug, 500W Einspeisung, keine Batterie
+    assert_equal(2500, current_consumption(3000, 0, 500, 0))
+  end
+
+  def test_current_consumption_battery_discharging
+    # Batterie entlädt 2000W → battery_power = -2000, battery_discharge = 2000
+    # Gesamtlast = 1000 + 500 - 0 + 2000 = 3500
+    assert_equal(3500, current_consumption(1000, 500, 0, -2000))
+  end
+
+  def test_current_consumption_battery_charging
+    # Batterie lädt 2000W → battery_power = +2000, battery_discharge = 0
+    # Laden bereits im Zähler sichtbar → keine Korrektur
+    # Gesamtlast = 5000 + 0 - 1000 + 0 = 4000 (Haus 2000W + Batterieladen 2000W)
+    assert_equal(4000, current_consumption(5000, 0, 1000, 2000))
+  end
+
+  def test_current_consumption_defaults_battery_to_zero
+    # Rückwärtskompatibilität: 3-Argument-Aufruf muss weiterhin funktionieren
+    assert_equal(2500, current_consumption(3000, 0, 500))
   end
 end
 


### PR DESCRIPTION
## Summary
- `wattmeter_house_power_consumption` zeigt jetzt echte Gesamtlast (Haus + Batterie-Laden + Batterie-Entladung)
- Batterie-Entladung wird zur Berechnung addiert, da der Netzzähler sie nicht sieht (Powerwall ist hinter dem Zähler)
- Batterie-Laden ist im Zähler bereits sichtbar und braucht keine Korrektur
- `powerwall.rb` schreibt `$powerwall_battery_power` als geteilte Variable für `grid_watts.rb`
- `grid_watts.rb` bekommt `if defined?(SCHEDULER)` Guard (wie `weather.rb`) für Testbarkeit

## Test plan
- [x] 5 neue Tests in `GridWattsTest` für `current_consumption` mit Batterie
- [x] Alle 55 Tests grün: `bundle exec ruby -r simplecov -Itest test/unit_test.rb`
- [x] Dashboard `p2.erb` → Verbrauch-Widget zeigt Solar + Netzbezug + Batterie-Entladung

🤖 Generated with [Claude Code](https://claude.com/claude-code)