### PR TITLE
feat: energy flow SVG widget and dashboard

### DIFF
--- a/dashboards/energyflow.erb
+++ b/dashboards/energyflow.erb
@@ -1,0 +1,60 @@
+<script>Dashing.numColumns = 6;</script>
+
+<div class="gridster">
+  <ul>
+
+    <!-- ═══ 4×2 Energy Flow Widget ═══ -->
+    <li data-row="1" data-col="1" data-sizex="4" data-sizey="2">
+      <div data-id="energyflow"
+           data-view="Energyflow"
+           data-title=""
+           style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);">
+      </div>
+    </li>
+
+    <!-- ═══ Detail Kacheln (rechts, 1×1 je) ═══ -->
+
+    <!-- Solar Tagesproduktion — Event von solar_production_per_day.rb -->
+    <li data-row="1" data-col="5" data-sizex="1" data-sizey="1">
+      <div data-id="wattmetersolar_sum"
+           data-view="Number"
+           data-title="Solar heute"
+           data-moreinfo="kWh"
+           style="background-color:#c8860a;">
+      </div>
+    </li>
+
+    <!-- Powerwall SOC — Event von powerwall.rb -->
+    <li data-row="1" data-col="6" data-sizex="1" data-sizey="1">
+      <div data-id="powerwall_soc"
+           data-view="Meter"
+           data-title="Akku"
+           data-moreinfo="Ladestand in %"
+           data-min="0"
+           data-max="100"
+           style="background-color:#2e7d32;">
+      </div>
+    </li>
+
+    <!-- Netzbezug heute — Event von grid_consumption_per_day.rb -->
+    <li data-row="2" data-col="5" data-sizex="1" data-sizey="1">
+      <div data-id="meter_grid_supply_sum"
+           data-view="Number"
+           data-title="Netzbezug"
+           data-moreinfo="kWh heute"
+           style="background-color:#2a6db5;">
+      </div>
+    </li>
+
+    <!-- Wärmepumpe heute — Event von heating_consumption_per_day.rb -->
+    <li data-row="2" data-col="6" data-sizex="1" data-sizey="1">
+      <div data-id="wattmeterheating_sum"
+           data-view="Number"
+           data-title="Wärmepumpe"
+           data-moreinfo="kWh heute"
+           style="background-color:#a0522d;">
+      </div>
+    </li>
+
+  </ul>
+</div>

--- a/jobs/energyflow.rb
+++ b/jobs/energyflow.rb
@@ -1,0 +1,53 @@
+require_relative 'meter_helper/grid_meter_client'
+require_relative 'meter_helper/solar_meter_client'
+require_relative 'meter_helper/opendtu_meter_client'
+require_relative 'meter_helper/powerwall_client'
+require_relative 'meter_helper/heating_meter_client'
+
+if defined?(SCHEDULER)
+  SCHEDULER.every '3s', :first_in => 0 do |job|
+    begin
+      grid      = GridMeasurements.new
+      solar     = SolarMeasurements.new
+      opendtu   = OpenDTUMeterClient.new
+      powerwall = PowerwallClient.new
+      heating   = HeatingMeasurements.new
+
+      # Combine SMA inverter + OpenDTU (same pattern as solar_watts.rb)
+      combined_solar = OpenStruct.new(
+        solar_watts_current: solar.solar_watts_current + opendtu.power_watts
+      )
+
+      payload = build_energyflow_payload(grid, combined_solar, powerwall, heating)
+      send_event('energyflow', payload)
+    rescue => e
+      puts "[EnergyFlow] Error: #{e.message}"
+    end
+  end
+end
+
+# Extracted for testability — takes duck-typed client objects
+def build_energyflow_payload(grid, solar, powerwall, heating)
+  solar_w       = solar.solar_watts_current.to_f
+  grid_supply_w = (grid.grid_supply_current * 1000).round(0)
+  grid_feed_w   = (grid.grid_feed_current * 1000).round(0)
+  battery_w     = powerwall.power_watts.to_f
+  heatpump_w    = heating.heating_watts_current.to_f
+
+  # positive = Bezug (supply from grid), negative = Einspeisung (feed into grid)
+  grid_w = grid_supply_w - grid_feed_w
+
+  # Battery: positive = charging, negative = discharging
+  # Discharge adds to available power (makes house consumption appear higher)
+  battery_discharge = [-battery_w, 0].max
+  house_w = solar_w + grid_supply_w - grid_feed_w + battery_discharge
+
+  {
+    solar_w:     solar_w.round(0),
+    grid_w:      grid_w,
+    battery_w:   battery_w.round(0),
+    battery_soc: powerwall.soc_percent,
+    house_w:     house_w.round(0),
+    heatpump_w:  heatpump_w.round(0)
+  }
+end

--- a/test/energyflow_test.rb
+++ b/test/energyflow_test.rb
@@ -1,0 +1,86 @@
+require_relative 'test_helper'
+require 'ostruct'
+require_relative '../jobs/energyflow'
+
+class EnergyflowTest < Minitest::Test
+  def test_house_consumption_solar_only
+    # Solar produces 2400W, nothing else active
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.0, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 2400),
+      OpenStruct.new(power_watts: 0.0, soc_percent: 80),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal 2400, payload[:house_w]
+    assert_equal 2400, payload[:solar_w]
+    assert_equal 0,    payload[:grid_w]
+  end
+
+  def test_house_consumption_grid_supply
+    # 1kW from grid, 0 solar
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 1.0, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 0),
+      OpenStruct.new(power_watts: 0.0, soc_percent: 50),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal 1000, payload[:house_w]
+    assert_equal 1000, payload[:grid_w]   # positive = supply (Bezug)
+  end
+
+  def test_grid_w_negative_when_feeding_in
+    # Solar produces 3kW, house uses 1kW → feed 2kW
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.0, grid_feed_current: 2.0),
+      OpenStruct.new(solar_watts_current: 3000),
+      OpenStruct.new(power_watts: 0.0, soc_percent: 100),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal(-2000, payload[:grid_w])   # negative = Einspeisung
+    assert_equal 1000,  payload[:house_w]   # 3000 - 2000 = 1000W house
+  end
+
+  def test_battery_discharge_adds_to_house
+    # Battery discharges 500W (power_watts = -500)
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.0, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 1000),
+      OpenStruct.new(power_watts: -500.0, soc_percent: 60),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal(-500, payload[:battery_w])
+    assert_equal 1500, payload[:house_w]    # 1000 solar + 500 discharge
+  end
+
+  def test_battery_charging_does_not_add_to_house
+    # Battery charges 800W (power_watts = +800) — charging takes power FROM house, not adds
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.0, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 3000),
+      OpenStruct.new(power_watts: 800.0, soc_percent: 40),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal 800,  payload[:battery_w]
+    assert_equal 3000, payload[:house_w]   # battery_discharge = 0, so house = solar only
+  end
+
+  def test_heatpump_w_from_heating_client
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.5, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 0),
+      OpenStruct.new(power_watts: 0.0, soc_percent: 70),
+      OpenStruct.new(heating_watts_current: 600)
+    )
+    assert_equal 600, payload[:heatpump_w]
+  end
+
+  def test_battery_soc_included
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.0, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 0),
+      OpenStruct.new(power_watts: 0.0, soc_percent: 78),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal 78, payload[:battery_soc]
+  end
+end

--- a/widgets/energyflow/energyflow.coffee
+++ b/widgets/energyflow/energyflow.coffee
@@ -1,0 +1,69 @@
+class Dashing.Energyflow extends Dashing.Widget
+
+  THRESHOLD = 50    # Watts below which a flow is considered inactive
+
+  ready: ->
+    # Initial state: all paths inactive
+    paths = @node.querySelectorAll('.flow-path')
+    path.classList.remove('active', 'reverse') for path in paths
+
+  onData: (data) ->
+    return unless data
+
+    # ─── Update node watt displays ───────────────────────────
+    @setText('val-solar',    "#{data.solar_w} W")
+    @setText('val-grid',     "#{Math.abs(data.grid_w)} W")
+    @setText('val-house',    "#{data.house_w} W")
+    @setText('val-heatpump', "#{data.heatpump_w} W")
+    @setText('val-battery',  "#{Math.abs(data.battery_w)} W")
+    @setText('val-soc',      "#{data.battery_soc}%")
+
+    # Grid label flips between Bezug and Einspeisung
+    @setText('lbl-grid', if data.grid_w < -THRESHOLD then 'Einspeisung' else 'Netz')
+
+    # ─── Solar → Haus ────────────────────────────────────────
+    @setFlow('solar-house', data.solar_w > THRESHOLD, false)
+    @setSpeed('solar-house', data.solar_w)
+
+    # ─── Grid ↔ Haus (same path, direction via reverse class) ─
+    if data.grid_w > THRESHOLD
+      @setFlow('grid-house', true, false)   # Bezug: grid → haus
+    else if data.grid_w < -THRESHOLD
+      @setFlow('grid-house', true, true)    # Einspeisung: haus → grid
+    else
+      @setFlow('grid-house', false, false)
+    @setSpeed('grid-house', Math.abs(data.grid_w))
+
+    # ─── Haus → Wärmepumpe ───────────────────────────────────
+    @setFlow('house-heatpump', data.heatpump_w > THRESHOLD, false)
+    @setSpeed('house-heatpump', data.heatpump_w)
+
+    # ─── Haus ↔ Akku (same path, direction via reverse class) ─
+    if data.battery_w > THRESHOLD
+      @setFlow('house-battery', true, false)   # Laden: haus → akku
+    else if data.battery_w < -THRESHOLD
+      @setFlow('house-battery', true, true)    # Entladen: akku → haus
+    else
+      @setFlow('house-battery', false, false)
+    @setSpeed('house-battery', Math.abs(data.battery_w))
+
+  # Toggle active/reverse CSS classes on a flow path
+  setFlow: (flowId, active, reverse) ->
+    el = @node.querySelector("[data-flow='#{flowId}']")
+    return unless el
+    el.classList.toggle('active', active)
+    el.classList.toggle('reverse', active and reverse)
+
+  # Scale animation speed to watt value (faster = more power)
+  # Range: 0.6s at 5000W → 3.0s at 0W
+  setSpeed: (flowId, watts) ->
+    el = @node.querySelector("[data-flow='#{flowId}']")
+    return unless el
+    return unless el.classList.contains('active')
+    speed = Math.max(0.6, 3.0 - (watts / 2000.0))
+    el.style.animationDuration = "#{speed.toFixed(1)}s"
+
+  # Safely update SVG text content by element ID
+  setText: (id, text) ->
+    el = @node.querySelector("##{id}")
+    el.textContent = text if el

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -1,0 +1,73 @@
+<div class="energyflow-container">
+  <svg viewBox="0 0 760 360" xmlns="http://www.w3.org/2000/svg" class="energyflow-svg">
+
+    <!-- ═══ FLOW PATHS (drawn behind nodes) ═══ -->
+
+    <!-- Solar → Haus (top to center, downward) -->
+    <path data-flow="solar-house"
+          class="flow-path"
+          d="M 380,115 L 380,162"/>
+
+    <!-- Grid ↔ Haus (left to center, horizontal) -->
+    <!-- Same path used for Bezug (forward) and Einspeisung (reverse) -->
+    <path data-flow="grid-house"
+          class="flow-path"
+          d="M 140,200 L 332,200"/>
+
+    <!-- Haus → WP (center to right, horizontal) -->
+    <path data-flow="house-heatpump"
+          class="flow-path"
+          d="M 428,200 L 620,200"/>
+
+    <!-- Haus ↔ Akku (center to bottom, downward) -->
+    <!-- Same path: forward = charging, reverse = discharging -->
+    <path data-flow="house-battery"
+          class="flow-path"
+          d="M 380,238 L 380,292"/>
+
+    <!-- ═══ NODES ═══ -->
+
+    <!-- Solar: top center (380, 75) -->
+    <g class="ef-node" id="node-solar" transform="translate(380,75)">
+      <circle class="node-circle solar" r="40"/>
+      <text class="node-icon" font-family="FontAwesome" font-size="22" text-anchor="middle" dy="-5">&#xf185;</text>
+      <text class="node-label" text-anchor="middle" dy="10">Solar</text>
+      <text class="node-value" id="val-solar" text-anchor="middle" dy="26">-- W</text>
+    </g>
+
+    <!-- Grid: left middle (90, 200) -->
+    <g class="ef-node" id="node-grid" transform="translate(90,200)">
+      <circle class="node-circle grid" r="40"/>
+      <text class="node-icon" font-family="FontAwesome" font-size="22" text-anchor="middle" dy="-5">&#xf0e7;</text>
+      <text class="node-label" id="lbl-grid" text-anchor="middle" dy="10">Netz</text>
+      <text class="node-value" id="val-grid" text-anchor="middle" dy="26">-- W</text>
+    </g>
+
+    <!-- Haus: center (380, 200) -->
+    <g class="ef-node" id="node-house" transform="translate(380,200)">
+      <circle class="node-circle house" r="46"/>
+      <text class="node-icon" font-family="FontAwesome" font-size="26" text-anchor="middle" dy="-6">&#xf015;</text>
+      <text class="node-label" text-anchor="middle" dy="12">Haus</text>
+      <text class="node-value" id="val-house" text-anchor="middle" dy="28">-- W</text>
+    </g>
+
+    <!-- Wärmepumpe: right middle (670, 200) -->
+    <g class="ef-node" id="node-heatpump" transform="translate(670,200)">
+      <circle class="node-circle heatpump" r="40"/>
+      <text class="node-icon" font-family="FontAwesome" font-size="22" text-anchor="middle" dy="-5">&#xf06d;</text>
+      <text class="node-label" text-anchor="middle" dy="10">WP</text>
+      <text class="node-value" id="val-heatpump" text-anchor="middle" dy="26">-- W</text>
+    </g>
+
+    <!-- Akku: bottom center (380, 330) -->
+    <g class="ef-node" id="node-battery" transform="translate(380,330)">
+      <circle class="node-circle battery" r="40"/>
+      <text class="node-icon" font-family="FontAwesome" font-size="22" text-anchor="middle" dy="-8">&#xf240;</text>
+      <text class="node-soc" id="val-soc" text-anchor="middle" dy="6">--%</text>
+      <text class="node-value" id="val-battery" text-anchor="middle" dy="22">-- W</text>
+    </g>
+
+  </svg>
+</div>
+
+<p class="updated-at" data-bind="updatedAtMessage"></p>

--- a/widgets/energyflow/energyflow.scss
+++ b/widgets/energyflow/energyflow.scss
@@ -1,0 +1,85 @@
+.widget-energyflow {
+  padding: 5px;
+
+  .energyflow-container {
+    width: 100%;
+    height: calc(100% - 20px);
+  }
+
+  .energyflow-svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  // ─── Flow paths ───────────────────────────────────────────
+  .flow-path {
+    fill: none;
+    stroke: rgba(255, 255, 255, 0.12);
+    stroke-width: 5;
+    stroke-linecap: round;
+    stroke-dasharray: none;
+    transition: stroke 0.5s ease;
+
+    &.active {
+      stroke: rgba(255, 255, 255, 0.75);
+      stroke-dasharray: 8 18;
+      animation: flow-forward 1.8s linear infinite;
+    }
+
+    &.active.reverse {
+      animation: flow-reverse 1.8s linear infinite;
+    }
+  }
+
+  @keyframes flow-forward {
+    from { stroke-dashoffset: 26; }
+    to   { stroke-dashoffset: 0; }
+  }
+
+  @keyframes flow-reverse {
+    from { stroke-dashoffset: 0; }
+    to   { stroke-dashoffset: 26; }
+  }
+
+  // ─── Nodes ────────────────────────────────────────────────
+  .node-circle {
+    stroke: rgba(255, 255, 255, 0.25);
+    stroke-width: 2;
+
+    &.solar    { fill: #c8860a; }  // amber
+    &.grid     { fill: #2a6db5; }  // blue
+    &.house    { fill: #4a4a6a; }  // dark blue-grey
+    &.heatpump { fill: #a0522d; }  // sienna
+    &.battery  { fill: #2e7d32; }  // green
+  }
+
+  .node-icon {
+    fill: rgba(255, 255, 255, 0.9);
+  }
+
+  .node-label {
+    fill: rgba(255, 255, 255, 0.65);
+    font-size: 11px;
+    font-weight: 300;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .node-value {
+    fill: #ffffff;
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .node-soc {
+    fill: #a5d6a7;
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  // ─── Bottom label ─────────────────────────────────────────
+  .updated-at {
+    font-size: 10px;
+    opacity: 0.5;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `widgets/energyflow/` — SVG widget with 5 nodes (Solar, Netz, Haus, Wärmepumpe, Akku) and 4 animated flow paths
- CSS keyframe animation with dashed-stroke paths; direction controlled by `active`/`reverse` classes
- Animation speed scales with watt value (0.6s at 5kW → 3.0s at 0W)
- Adds `dashboards/energyflow.erb` — 4×2 flow widget + 4 detail kacheln reusing existing event IDs
- 6-column layout via `Dashing.numColumns = 6` script override

## Depends on
- PR `feature/energyflow-job` (provides the `energyflow` event with `solar_w`, `grid_w`, `battery_w`, `battery_soc`, `house_w`, `heatpump_w`)

## Test plan
- [ ] Open `http://localhost:3030/energyflow` — SVG renders with 5 nodes and correct colors
- [ ] Flow paths visible as faint lines when inactive
- [ ] With energyflow job running: values update, paths animate
- [ ] Grid path shows `Einspeisung` label and reverse animation when `grid_w < -50`
- [ ] Battery path direction reverses when `battery_w < -50`
- [ ] Animation speed varies: higher watts = faster flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)