### PR TITLE
feat: energy flow aggregator job

### DIFF
--- a/jobs/energyflow.rb
+++ b/jobs/energyflow.rb
@@ -1,0 +1,53 @@
+require_relative 'meter_helper/grid_meter_client'
+require_relative 'meter_helper/solar_meter_client'
+require_relative 'meter_helper/opendtu_meter_client'
+require_relative 'meter_helper/powerwall_client'
+require_relative 'meter_helper/heating_meter_client'
+
+if defined?(SCHEDULER)
+  SCHEDULER.every '3s', :first_in => 0 do |job|
+    begin
+      grid      = GridMeasurements.new
+      solar     = SolarMeasurements.new
+      opendtu   = OpenDTUMeterClient.new
+      powerwall = PowerwallClient.new
+      heating   = HeatingMeasurements.new
+
+      # Combine SMA inverter + OpenDTU (same pattern as solar_watts.rb)
+      combined_solar = OpenStruct.new(
+        solar_watts_current: solar.solar_watts_current + opendtu.power_watts
+      )
+
+      payload = build_energyflow_payload(grid, combined_solar, powerwall, heating)
+      send_event('energyflow', payload)
+    rescue => e
+      puts "[EnergyFlow] Error: #{e.message}"
+    end
+  end
+end
+
+# Extracted for testability — takes duck-typed client objects
+def build_energyflow_payload(grid, solar, powerwall, heating)
+  solar_w       = solar.solar_watts_current.to_f
+  grid_supply_w = (grid.grid_supply_current * 1000).round(0)
+  grid_feed_w   = (grid.grid_feed_current * 1000).round(0)
+  battery_w     = powerwall.power_watts.to_f
+  heatpump_w    = heating.heating_watts_current.to_f
+
+  # positive = Bezug (supply from grid), negative = Einspeisung (feed into grid)
+  grid_w = grid_supply_w - grid_feed_w
+
+  # Battery: positive = charging, negative = discharging
+  # Discharge adds to available power (makes house consumption appear higher)
+  battery_discharge = [-battery_w, 0].max
+  house_w = solar_w + grid_supply_w - grid_feed_w + battery_discharge
+
+  {
+    solar_w:     solar_w.round(0),
+    grid_w:      grid_w,
+    battery_w:   battery_w.round(0),
+    battery_soc: powerwall.soc_percent,
+    house_w:     house_w.round(0),
+    heatpump_w:  heatpump_w.round(0)
+  }
+end

--- a/test/energyflow_test.rb
+++ b/test/energyflow_test.rb
@@ -1,0 +1,86 @@
+require_relative 'test_helper'
+require 'ostruct'
+require_relative '../jobs/energyflow'
+
+class EnergyflowTest < Minitest::Test
+  def test_house_consumption_solar_only
+    # Solar produces 2400W, nothing else active
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.0, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 2400),
+      OpenStruct.new(power_watts: 0.0, soc_percent: 80),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal 2400, payload[:house_w]
+    assert_equal 2400, payload[:solar_w]
+    assert_equal 0,    payload[:grid_w]
+  end
+
+  def test_house_consumption_grid_supply
+    # 1kW from grid, 0 solar
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 1.0, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 0),
+      OpenStruct.new(power_watts: 0.0, soc_percent: 50),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal 1000, payload[:house_w]
+    assert_equal 1000, payload[:grid_w]   # positive = supply (Bezug)
+  end
+
+  def test_grid_w_negative_when_feeding_in
+    # Solar produces 3kW, house uses 1kW → feed 2kW
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.0, grid_feed_current: 2.0),
+      OpenStruct.new(solar_watts_current: 3000),
+      OpenStruct.new(power_watts: 0.0, soc_percent: 100),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal(-2000, payload[:grid_w])   # negative = Einspeisung
+    assert_equal 1000,  payload[:house_w]   # 3000 - 2000 = 1000W house
+  end
+
+  def test_battery_discharge_adds_to_house
+    # Battery discharges 500W (power_watts = -500)
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.0, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 1000),
+      OpenStruct.new(power_watts: -500.0, soc_percent: 60),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal(-500, payload[:battery_w])
+    assert_equal 1500, payload[:house_w]    # 1000 solar + 500 discharge
+  end
+
+  def test_battery_charging_does_not_add_to_house
+    # Battery charges 800W (power_watts = +800) — charging takes power FROM house, not adds
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.0, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 3000),
+      OpenStruct.new(power_watts: 800.0, soc_percent: 40),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal 800,  payload[:battery_w]
+    assert_equal 3000, payload[:house_w]   # battery_discharge = 0, so house = solar only
+  end
+
+  def test_heatpump_w_from_heating_client
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.5, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 0),
+      OpenStruct.new(power_watts: 0.0, soc_percent: 70),
+      OpenStruct.new(heating_watts_current: 600)
+    )
+    assert_equal 600, payload[:heatpump_w]
+  end
+
+  def test_battery_soc_included
+    payload = build_energyflow_payload(
+      OpenStruct.new(grid_supply_current: 0.0, grid_feed_current: 0.0),
+      OpenStruct.new(solar_watts_current: 0),
+      OpenStruct.new(power_watts: 0.0, soc_percent: 78),
+      OpenStruct.new(heating_watts_current: 0)
+    )
+    assert_equal 78, payload[:battery_soc]
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `jobs/energyflow.rb` with `build_energyflow_payload` helper (fully tested with OpenStruct mocks)
- Sends single `energyflow` event every 3s with: `solar_w`, `grid_w`, `battery_w`, `battery_soc`, `house_w`, `heatpump_w`
- Combines SMA inverter + OpenDTU solar sources (same pattern as `solar_watts.rb`)
- Uses `if defined?(SCHEDULER)` guard so the file is safely loadable in tests

## Formula

```
house_w = solar_w + grid_supply_w - grid_feed_w + battery_discharge_w
grid_w  = grid_supply_w - grid_feed_w  (positive = Bezug, negative = Einspeisung)
```

## Test plan

- [x] 7 unit tests covering all energy flow scenarios (solar-only, grid supply, feed-in, battery charge/discharge, heatpump, SOC)
- [x] Full test suite (55 runs, 0 failures) — existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)