### PR TITLE
feat: add weather panel to energyflow widget

### DIFF
--- a/docs/plans/2026-02-28-weather-in-energyflow.md
+++ b/docs/plans/2026-02-28-weather-in-energyflow.md
@@ -1,0 +1,291 @@
+# Weather in Energyflow Widget – Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wetterdaten (Temperatur, Icon, Wind, 2-Tages-Forecast) oben-rechts im Energyflow-SVG anzeigen.
+
+**Architecture:** Das Energyflow-Widget subscribt über `Dashing.on 'weather_temperature'` manuell auf einen zweiten Event. `weather.rb` und `energyflow.rb` bleiben unverändert. Alle Änderungen sind rein frontend: HTML (SVG-Elemente), SCSS (Styling), CoffeeScript (Event-Handler + Icon-Mapping).
+
+**Tech Stack:** Smashing (Dashing fork), SVG, CoffeeScript, SCSS
+
+---
+
+## Hintergrund
+
+- SVG viewBox: `0 0 760 360`
+- Solar-Node: `translate(380,75)` r=40 → belegt x:340–420, y:35–115
+- Freie Fläche oben-rechts: x≈455–752, y≈15–115
+- Weather-Event: `weather_temperature` mit Feldern `current` (Temp), `climacon_code`, `wind_speed`, `forecast1`, `forecast1_climacon`, `forecast1_day`, `forecast2`, `forecast2_climacon`, `forecast2_day`
+- Climacon-Codes sind Zahlen (32=Sonne, 26=Wolke+Sonne, 20=Nebel, 12=Regen, etc.)
+
+---
+
+## Task 1: SVG-Wetter-Panel in `energyflow.html` einfügen
+
+**Files:**
+- Modify: `widgets/energyflow/energyflow.html`
+
+**Step 1: Wetter-Gruppe vor dem schließenden `</svg>` einfügen**
+
+Füge diese `<g>`-Gruppe direkt vor `</svg>` ein (nach dem Akku-Node):
+
+```html
+    <!-- ═══ WEATHER PANEL (top-right) ═══ -->
+    <g id="weather-panel">
+      <!-- Current weather: icon + temperature -->
+      <text id="weather-icon"
+            class="weather-icon"
+            x="471" y="44"
+            text-anchor="middle">--</text>
+      <text id="weather-temp"
+            class="weather-temp"
+            x="497" y="44">--°</text>
+
+      <!-- Wind speed -->
+      <text id="weather-wind"
+            class="weather-wind"
+            x="497" y="60">-- km/h</text>
+
+      <!-- Separator line -->
+      <line class="weather-separator" x1="455" y1="68" x2="752" y2="68"/>
+
+      <!-- Forecast 1 -->
+      <g id="fc1-group" transform="translate(490, 0)">
+        <text id="fc1-day"  class="weather-fc-day"  x="0" y="83">---</text>
+        <text id="fc1-icon" class="weather-fc-icon" x="0" y="100">--</text>
+        <text id="fc1-temp" class="weather-fc-temp" x="0" y="114">--</text>
+      </g>
+
+      <!-- Forecast 2 -->
+      <g id="fc2-group" transform="translate(625, 0)">
+        <text id="fc2-day"  class="weather-fc-day"  x="0" y="83">---</text>
+        <text id="fc2-icon" class="weather-fc-icon" x="0" y="100">--</text>
+        <text id="fc2-temp" class="weather-fc-temp" x="0" y="114">--</text>
+      </g>
+    </g>
+```
+
+**Step 2: Datei vergleichen / prüfen**
+
+Öffne `widgets/energyflow/energyflow.html` und stelle sicher:
+- Die `<g id="weather-panel">` steht vor `</svg>` (nach dem Akku-Node `</g>`)
+- Alle IDs sind korrekt: `weather-icon`, `weather-temp`, `weather-wind`, `fc1-day`, `fc1-icon`, `fc1-temp`, `fc2-day`, `fc2-icon`, `fc2-temp`
+
+**Step 3: Commit**
+
+```bash
+git add widgets/energyflow/energyflow.html
+git commit -m "feat: add weather panel SVG elements to energyflow widget"
+```
+
+---
+
+## Task 2: CSS-Styling in `energyflow.scss`
+
+**Files:**
+- Modify: `widgets/energyflow/energyflow.scss`
+
+**Step 1: Wetter-Styles am Ende des `.widget-energyflow`-Blocks einfügen**
+
+Füge vor der letzten schließenden `}` des `.widget-energyflow`-Blocks ein:
+
+```scss
+  // ─── Weather panel (top-right) ────────────────────────
+  .weather-icon {
+    fill: rgba(255, 255, 255, 0.95);
+    font-size: 22px;
+  }
+
+  .weather-temp {
+    fill: #ffffff;
+    font-size: 20px;
+    font-weight: 600;
+  }
+
+  .weather-wind {
+    fill: rgba(255, 255, 255, 0.55);
+    font-size: 12px;
+    font-weight: 300;
+  }
+
+  .weather-separator {
+    stroke: rgba(255, 255, 255, 0.15);
+    stroke-width: 1;
+  }
+
+  .weather-fc-day {
+    fill: rgba(255, 255, 255, 0.55);
+    font-size: 11px;
+    font-weight: 300;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .weather-fc-icon {
+    fill: rgba(255, 255, 255, 0.9);
+    font-size: 17px;
+  }
+
+  .weather-fc-temp {
+    fill: rgba(255, 255, 255, 0.75);
+    font-size: 11px;
+  }
+```
+
+**Step 2: Commit**
+
+```bash
+git add widgets/energyflow/energyflow.scss
+git commit -m "feat: add weather panel styles to energyflow widget"
+```
+
+---
+
+## Task 3: CoffeeScript – Weather-Event subscriben und Panel befüllen
+
+**Files:**
+- Modify: `widgets/energyflow/energyflow.coffee`
+
+**Step 1: Climacon→Emoji-Map und Dashing.on-Handler hinzufügen**
+
+Füge am **Anfang** der Klasse (direkt nach `class Dashing.Energyflow extends Dashing.Widget`) ein:
+
+```coffeescript
+  CLIMACON_TO_EMOJI =
+    32: '☀'   # Sonne
+    26: '⛅'  # Wolke + Sonne
+    20: '🌫'  # Nebel
+    12: '🌧'  # Regen
+    11: '🌧'  # Regenschauer
+    9:  '🌦'  # Nieselregen
+    18: '🌨'  # Gefrierender Regen / Schneeregen
+    16: '❄'   # Schnee
+    17: '❄'   # Schneekörner
+    6:  '⚡'  # Gewitter
+```
+
+Füge dann in der `ready:`-Methode (oder als neue Methode nach `ready:`) den zweiten Event-Listener ein:
+
+```coffeescript
+  ready: ->
+    # Initial state: all paths inactive
+    paths = @node.querySelectorAll('.flow-path')
+    path.classList.remove('active', 'reverse') for path in paths
+
+    # Subscribe to weather event (independent of energyflow event)
+    self = @
+    Dashing.on 'weather_temperature', (event, data) ->
+      return unless data
+      self.updateWeather(data)
+```
+
+Füge am Ende der Klasse die `updateWeather`-Methode hinzu:
+
+```coffeescript
+  updateWeather: (data) ->
+    icon = CLIMACON_TO_EMOJI[data.climacon_code] or '?'
+    @setText('weather-icon', icon)
+    @setText('weather-temp', "#{data.current}°")
+    @setText('weather-wind', "≈ #{data.wind_speed} km/h")
+
+    fc1Icon = CLIMACON_TO_EMOJI[data.forecast1_climacon] or '?'
+    @setText('fc1-day',  data.forecast1_day)
+    @setText('fc1-icon', fc1Icon)
+    @setText('fc1-temp', data.forecast1)
+
+    fc2Icon = CLIMACON_TO_EMOJI[data.forecast2_climacon] or '?'
+    @setText('fc2-day',  data.forecast2_day)
+    @setText('fc2-icon', fc2Icon)
+    @setText('fc2-temp', data.forecast2)
+```
+
+**Step 2: Vollständige Datei prüfen**
+
+Die finale Struktur von `energyflow.coffee` sollte so aussehen:
+
+```
+class Dashing.Energyflow extends Dashing.Widget
+
+  THRESHOLD = 50
+  CLIMACON_TO_EMOJI = { ... }
+
+  ready: ->
+    # paths inactive ...
+    # Dashing.on 'weather_temperature' ...
+
+  onData: (data) ->
+    # setText calls for energy values ...
+    # setFlow / setSpeed calls ...
+
+  setFlow: (flowId, active, reverse) -> ...
+  setSpeed: (flowId, watts) -> ...
+  setText: (id, text) -> ...
+  updateWeather: (data) -> ...
+```
+
+**Step 3: Commit**
+
+```bash
+git add widgets/energyflow/energyflow.coffee
+git commit -m "feat: subscribe to weather event and display in energyflow widget"
+```
+
+---
+
+## Task 4: Manueller Test im Dashboard
+
+**Step 1: Dashboard starten**
+
+```bash
+bundle exec smashing start
+# Öffne http://localhost:3030/energyflow
+```
+
+**Step 2: Prüfen**
+
+- [ ] Oben-rechts erscheinen Wetter-Platzhalter (`--°`, `-- km/h`)
+- [ ] Nach max. 10 Minuten (oder nach `curl -d '{}' http://localhost:3030/widgets/weather_temperature`): echte Wetterdaten erscheinen
+- [ ] Icon, Temperatur und Wind werden angezeigt
+- [ ] Forecast-Bereich zeigt Wochentag, Icon, Min/Max-Temperatur
+- [ ] Wetter-Panel überlagert keine Energie-Nodes (visuell prüfen)
+- [ ] Energie-Flow (Pfeile, Werte) funktioniert weiterhin normal
+
+**Step 3: Weather-Event manuell auslösen (für schnellen Test)**
+
+```bash
+# In einem anderen Terminal, während Dashboard läuft:
+curl -d '{"current": "8.5", "climacon_code": 26, "wind_speed": "12.3", "forecast1": "6° – 12°", "forecast1_climacon": 32, "forecast1_day": "Montag", "forecast2": "8° – 15°", "forecast2_climacon": 0, "forecast2_day": "Dienstag"}' \
+     http://localhost:3030/widgets/weather_temperature
+```
+
+**Step 4: Abschluss-Commit (falls kosmetische Korrekturen nötig)**
+
+```bash
+git add widgets/energyflow/
+git commit -m "fix: adjust weather panel layout in energyflow widget"
+```
+
+---
+
+## Zusammenfassung der Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `widgets/energyflow/energyflow.html` | Neue `<g id="weather-panel">` mit 9 Text-/Line-Elementen |
+| `widgets/energyflow/energyflow.scss` | 7 neue CSS-Klassen für Wetter-Elemente |
+| `widgets/energyflow/energyflow.coffee` | `CLIMACON_TO_EMOJI`-Map, `Dashing.on`-Handler, `updateWeather()`-Methode |
+
+**Backend-Änderung** – `weather.rb` ergänzt um `wind_speed` als separates Feld im Event-Payload.
+
+---
+
+## Debugging-Erkenntnisse (nach Implementierung)
+
+### Problem 1: `Dashing.on` ist das falsche API
+`Dashing.on` ist Batman.App's Lifecycle-Event-System (`'run'`, `'reload'`), kein SSE-Subscription-Mechanismus. Die Callbacks wurden nie aufgerufen.
+
+### Problem 2: `ready:` ist zu spät für SSE-Registrierung
+Smashing baut die SSE-URL in `@layout.on 'ready'` aus `Object.keys(Dashing.widgets)`. Das Verhältnis zwischen Widget-`ready:` und Layout-`ready` ist in Batman.js asynchron/unzuverlässig. **Fix: Registrierung in den Constructor verschieben** – der läuft garantiert vor dem SSE-Aufbau.
+
+### Problem 3: `wind_speed` fehlte im Event-Payload
+`weather.rb` sendete `wind_speed` nur als Teil des `moreinfo`-Strings, nicht als separates Feld. Ergebnis: `"≈ undefined km/h"` im Widget.

--- a/jobs/weather.rb
+++ b/jobs/weather.rb
@@ -141,6 +141,7 @@ if defined?(SCHEDULER)
       current: weather.temperature,
       icon: weather.weather_icon,
       climacon_code: weather.climacon_code,
+      wind_speed: weather.wind_speed,
       moreinfo: "#{weather.weather_description}, Wind: #{weather.wind_speed} km/h",
       forecast1: weather.forecast1,
       forecast1_climacon: weather.forecast1_climacon,

--- a/widgets/energyflow/energyflow.coffee
+++ b/widgets/energyflow/energyflow.coffee
@@ -19,14 +19,19 @@ class Dashing.Energyflow extends Dashing.Widget
     paths = @node.querySelectorAll('.flow-path')
     path.classList.remove('active', 'reverse') for path in paths
 
-    # Subscribe to weather event (independent of energyflow event)
-    self = @
-    Dashing.on 'weather_temperature', (event, data) ->
-      return unless data
-      self.updateWeather(data)
+    # Register this widget to also receive weather_temperature events.
+    # Smashing filters SSE by Dashing.widgets keys — registering here ensures
+    # the server sends weather events to this dashboard too.
+    Dashing.widgets['weather_temperature'] ||= []
+    Dashing.widgets['weather_temperature'].push(@)
 
   onData: (data) ->
     return unless data
+
+    # Route weather events — they share onData since we registered for both
+    if data.id == 'weather_temperature'
+      @updateWeather(data)
+      return
 
     # ─── Update node watt displays ───────────────────────────
     @setText('val-solar',    "#{data.solar_w} W")

--- a/widgets/energyflow/energyflow.coffee
+++ b/widgets/energyflow/energyflow.coffee
@@ -2,10 +2,28 @@ class Dashing.Energyflow extends Dashing.Widget
 
   THRESHOLD = 50    # Watts below which a flow is considered inactive
 
+  CLIMACON_TO_EMOJI =
+    32: '☀'   # Sonne
+    26: '⛅'  # Wolke + Sonne
+    20: '🌫'  # Nebel
+    12: '🌧'  # Regen
+    11: '🌧'  # Regenschauer
+    9:  '🌦'  # Nieselregen
+    18: '🌨'  # Schneeregen
+    16: '❄'   # Schnee
+    17: '❄'   # Schneekörner
+    6:  '⚡'  # Gewitter
+
   ready: ->
     # Initial state: all paths inactive
     paths = @node.querySelectorAll('.flow-path')
     path.classList.remove('active', 'reverse') for path in paths
+
+    # Subscribe to weather event (independent of energyflow event)
+    self = @
+    Dashing.on 'weather_temperature', (event, data) ->
+      return unless data
+      self.updateWeather(data)
 
   onData: (data) ->
     return unless data
@@ -72,3 +90,14 @@ class Dashing.Energyflow extends Dashing.Widget
   setText: (id, text) ->
     el = @node.querySelector("##{id}")
     el.textContent = text if el
+
+  updateWeather: (data) ->
+    @setText('weather-icon', CLIMACON_TO_EMOJI[data.climacon_code] or '?')
+    @setText('weather-temp', "#{data.current}°")
+    @setText('weather-wind', "≈ #{data.wind_speed} km/h")
+    @setText('fc1-day',  data.forecast1_day)
+    @setText('fc1-icon', CLIMACON_TO_EMOJI[data.forecast1_climacon] or '?')
+    @setText('fc1-temp', data.forecast1)
+    @setText('fc2-day',  data.forecast2_day)
+    @setText('fc2-icon', CLIMACON_TO_EMOJI[data.forecast2_climacon] or '?')
+    @setText('fc2-temp', data.forecast2)

--- a/widgets/energyflow/energyflow.coffee
+++ b/widgets/energyflow/energyflow.coffee
@@ -14,16 +14,18 @@ class Dashing.Energyflow extends Dashing.Widget
     17: '❄'   # Schneekörner
     6:  '⚡'  # Gewitter
 
+  constructor: ->
+    super
+    # Register for weather_temperature events before the SSE URL is built.
+    # Smashing filters SSE by Dashing.widgets keys (built at layout ready),
+    # which fires AFTER ready: — so we register here in the constructor instead.
+    Dashing.widgets['weather_temperature'] ||= []
+    Dashing.widgets['weather_temperature'].push(@)
+
   ready: ->
     # Initial state: all paths inactive
     paths = @node.querySelectorAll('.flow-path')
     path.classList.remove('active', 'reverse') for path in paths
-
-    # Register this widget to also receive weather_temperature events.
-    # Smashing filters SSE by Dashing.widgets keys — registering here ensures
-    # the server sends weather events to this dashboard too.
-    Dashing.widgets['weather_temperature'] ||= []
-    Dashing.widgets['weather_temperature'].push(@)
 
   onData: (data) ->
     return unless data

--- a/widgets/energyflow/energyflow.coffee
+++ b/widgets/energyflow/energyflow.coffee
@@ -2,17 +2,18 @@ class Dashing.Energyflow extends Dashing.Widget
 
   THRESHOLD = 50    # Watts below which a flow is considered inactive
 
-  CLIMACON_TO_EMOJI =
-    32: '☀'   # Sonne
-    26: '⛅'  # Wolke + Sonne
-    20: '🌫'  # Nebel
-    12: '🌧'  # Regen
-    11: '🌧'  # Regenschauer
-    9:  '🌦'  # Nieselregen
-    18: '🌨'  # Schneeregen
-    16: '❄'   # Schnee
-    17: '❄'   # Schneekörner
-    6:  '⚡'  # Gewitter
+  # Unicode chars from Climacons-Font (matches climacons-font.css index mapping)
+  CLIMACON_TO_CHAR =
+    32: '\ue028'  # Sonne
+    26: '\ue000'  # Wolke + Sonne
+    20: '\ue01b'  # Nebel
+    12: '\ue006'  # Regen
+    11: '\ue006'  # Regenschauer
+    9:  '\ue00c'  # Nieselregen
+    18: '\ue00f'  # Schneeregen
+    16: '\ue018'  # Schnee
+    17: '\ue012'  # Schneekörner
+    6:  '\ue015'  # Gewitter
 
   constructor: ->
     super
@@ -99,12 +100,12 @@ class Dashing.Energyflow extends Dashing.Widget
     el.textContent = text if el
 
   updateWeather: (data) ->
-    @setText('weather-icon', CLIMACON_TO_EMOJI[data.climacon_code] or '?')
+    @setText('weather-icon', CLIMACON_TO_CHAR[data.climacon_code] or '?')
     @setText('weather-temp', "#{data.current}°")
     @setText('weather-wind', "≈ #{data.wind_speed} km/h")
     @setText('fc1-day',  data.forecast1_day)
-    @setText('fc1-icon', CLIMACON_TO_EMOJI[data.forecast1_climacon] or '?')
+    @setText('fc1-icon', CLIMACON_TO_CHAR[data.forecast1_climacon] or '?')
     @setText('fc1-temp', data.forecast1)
     @setText('fc2-day',  data.forecast2_day)
-    @setText('fc2-icon', CLIMACON_TO_EMOJI[data.forecast2_climacon] or '?')
+    @setText('fc2-icon', CLIMACON_TO_CHAR[data.forecast2_climacon] or '?')
     @setText('fc2-temp', data.forecast2)

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -77,7 +77,7 @@
     </g>
 
     <!-- ═══ WEATHER PANEL (top-right, single column) ═══ -->
-    <g id="weather-panel" transform="translate(548, 0)">
+    <g id="weather-panel" transform="translate(548, -22)">
       <!-- Current weather: icon + temp on one line, wind below -->
       <text id="weather-icon" class="weather-icon" x="14" y="42" text-anchor="middle">--</text>
       <text id="weather-temp" class="weather-temp" x="32" y="42">--°</text>

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -76,38 +76,25 @@
       <text class="node-value" id="val-battery" text-anchor="middle" dy="22">-- W</text>
     </g>
 
-    <!-- ═══ WEATHER PANEL (top-right) ═══ -->
-    <g id="weather-panel">
-      <!-- Current weather: icon + temperature + wind -->
-      <g id="current-weather" transform="translate(455, 0)">
-        <text id="weather-icon"
-              class="weather-icon"
-              x="14" y="38"
-              text-anchor="middle">--</text>
-        <text id="weather-temp"
-              class="weather-temp"
-              x="34" y="38">--°</text>
-        <text id="weather-wind"
-              class="weather-wind"
-              x="34" y="50">-- km/h</text>
-      </g>
+    <!-- ═══ WEATHER PANEL (top-right, single column) ═══ -->
+    <g id="weather-panel" transform="translate(548, 0)">
+      <!-- Current weather: icon + temp on one line, wind below -->
+      <text id="weather-icon" class="weather-icon" x="12" y="40" text-anchor="middle">--</text>
+      <text id="weather-temp" class="weather-temp" x="28" y="40">--°</text>
+      <text id="weather-wind" class="weather-wind" x="12" y="55">-- km/h</text>
 
       <!-- Separator line -->
-      <line class="weather-separator" x1="455" y1="57" x2="752" y2="57"/>
+      <line class="weather-separator" x1="0" y1="63" x2="204" y2="63"/>
 
-      <!-- Forecast 1: icon + day on same line, temp below -->
-      <g id="fc1-group" transform="translate(475, 0)">
-        <text id="fc1-icon" class="weather-fc-icon" x="0"  y="70">--</text>
-        <text id="fc1-day"  class="weather-fc-day"  x="20" y="70">---</text>
-        <text id="fc1-temp" class="weather-fc-temp" x="20" y="82">--</text>
-      </g>
+      <!-- Forecast 1: icon + day + temp inline -->
+      <text id="fc1-icon" class="weather-fc-icon" x="0"  y="79">--</text>
+      <text id="fc1-day"  class="weather-fc-day"  x="22" y="79">---</text>
+      <text id="fc1-temp" class="weather-fc-temp" x="90" y="79">--</text>
 
-      <!-- Forecast 2: icon + day on same line, temp below -->
-      <g id="fc2-group" transform="translate(618, 0)">
-        <text id="fc2-icon" class="weather-fc-icon" x="0"  y="70">--</text>
-        <text id="fc2-day"  class="weather-fc-day"  x="20" y="70">---</text>
-        <text id="fc2-temp" class="weather-fc-temp" x="20" y="82">--</text>
-      </g>
+      <!-- Forecast 2: icon + day + temp inline -->
+      <text id="fc2-icon" class="weather-fc-icon" x="0"  y="97">--</text>
+      <text id="fc2-day"  class="weather-fc-day"  x="22" y="97">---</text>
+      <text id="fc2-temp" class="weather-fc-temp" x="90" y="97">--</text>
     </g>
 
   </svg>

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -76,6 +76,40 @@
       <text class="node-value" id="val-battery" text-anchor="middle" dy="22">-- W</text>
     </g>
 
+    <!-- ═══ WEATHER PANEL (top-right) ═══ -->
+    <g id="weather-panel">
+      <!-- Current weather: icon + temperature -->
+      <text id="weather-icon"
+            class="weather-icon"
+            x="471" y="44"
+            text-anchor="middle">--</text>
+      <text id="weather-temp"
+            class="weather-temp"
+            x="497" y="44">--°</text>
+
+      <!-- Wind speed -->
+      <text id="weather-wind"
+            class="weather-wind"
+            x="497" y="60">-- km/h</text>
+
+      <!-- Separator line -->
+      <line class="weather-separator" x1="455" y1="68" x2="752" y2="68"/>
+
+      <!-- Forecast 1 -->
+      <g id="fc1-group" transform="translate(490, 0)">
+        <text id="fc1-day"  class="weather-fc-day"  x="0" y="83">---</text>
+        <text id="fc1-icon" class="weather-fc-icon" x="0" y="100">--</text>
+        <text id="fc1-temp" class="weather-fc-temp" x="0" y="114">--</text>
+      </g>
+
+      <!-- Forecast 2 -->
+      <g id="fc2-group" transform="translate(625, 0)">
+        <text id="fc2-day"  class="weather-fc-day"  x="0" y="83">---</text>
+        <text id="fc2-icon" class="weather-fc-icon" x="0" y="100">--</text>
+        <text id="fc2-temp" class="weather-fc-temp" x="0" y="114">--</text>
+      </g>
+    </g>
+
   </svg>
 </div>
 

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -78,10 +78,10 @@
 
     <!-- ═══ WEATHER PANEL (top-right, single column) ═══ -->
     <g id="weather-panel" transform="translate(548, -38)">
-      <!-- Current weather: icon + temp on one line, wind below -->
-      <text id="weather-icon" class="weather-icon" x="14" y="42" text-anchor="middle" font-family="Climacons-Font">--</text>
-      <text id="weather-temp" class="weather-temp" x="32" y="42">--°</text>
-      <text id="weather-wind" class="weather-wind" x="14" y="60">-- km/h</text>
+      <!-- Current weather: large icon spanning both rows, temp + wind stacked to the right -->
+      <text id="weather-icon" class="weather-icon" x="22" y="60" text-anchor="middle" font-family="Climacons-Font">--</text>
+      <text id="weather-temp" class="weather-temp" x="48" y="42">--°</text>
+      <text id="weather-wind" class="weather-wind" x="48" y="60">-- km/h</text>
 
       <!-- Separator line -->
       <line class="weather-separator" x1="0" y1="69" x2="204" y2="69"/>

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -82,31 +82,31 @@
       <g id="current-weather" transform="translate(455, 0)">
         <text id="weather-icon"
               class="weather-icon"
-              x="16" y="44"
+              x="14" y="38"
               text-anchor="middle">--</text>
         <text id="weather-temp"
               class="weather-temp"
-              x="42" y="44">--°</text>
+              x="34" y="38">--°</text>
         <text id="weather-wind"
               class="weather-wind"
-              x="42" y="60">-- km/h</text>
+              x="34" y="50">-- km/h</text>
       </g>
 
       <!-- Separator line -->
-      <line class="weather-separator" x1="455" y1="68" x2="752" y2="68"/>
+      <line class="weather-separator" x1="455" y1="57" x2="752" y2="57"/>
 
-      <!-- Forecast 1 -->
-      <g id="fc1-group" transform="translate(490, 0)">
-        <text id="fc1-day"  class="weather-fc-day"  x="0" y="83">---</text>
-        <text id="fc1-icon" class="weather-fc-icon" x="0" y="100">--</text>
-        <text id="fc1-temp" class="weather-fc-temp" x="0" y="114">--</text>
+      <!-- Forecast 1: icon + day on same line, temp below -->
+      <g id="fc1-group" transform="translate(475, 0)">
+        <text id="fc1-icon" class="weather-fc-icon" x="0"  y="70">--</text>
+        <text id="fc1-day"  class="weather-fc-day"  x="20" y="70">---</text>
+        <text id="fc1-temp" class="weather-fc-temp" x="20" y="82">--</text>
       </g>
 
-      <!-- Forecast 2 -->
-      <g id="fc2-group" transform="translate(625, 0)">
-        <text id="fc2-day"  class="weather-fc-day"  x="0" y="83">---</text>
-        <text id="fc2-icon" class="weather-fc-icon" x="0" y="100">--</text>
-        <text id="fc2-temp" class="weather-fc-temp" x="0" y="114">--</text>
+      <!-- Forecast 2: icon + day on same line, temp below -->
+      <g id="fc2-group" transform="translate(618, 0)">
+        <text id="fc2-icon" class="weather-fc-icon" x="0"  y="70">--</text>
+        <text id="fc2-day"  class="weather-fc-day"  x="20" y="70">---</text>
+        <text id="fc2-temp" class="weather-fc-temp" x="20" y="82">--</text>
       </g>
     </g>
 

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -79,22 +79,22 @@
     <!-- ═══ WEATHER PANEL (top-right, single column) ═══ -->
     <g id="weather-panel" transform="translate(548, 0)">
       <!-- Current weather: icon + temp on one line, wind below -->
-      <text id="weather-icon" class="weather-icon" x="12" y="40" text-anchor="middle">--</text>
-      <text id="weather-temp" class="weather-temp" x="28" y="40">--°</text>
-      <text id="weather-wind" class="weather-wind" x="12" y="55">-- km/h</text>
+      <text id="weather-icon" class="weather-icon" x="14" y="42" text-anchor="middle">--</text>
+      <text id="weather-temp" class="weather-temp" x="32" y="42">--°</text>
+      <text id="weather-wind" class="weather-wind" x="14" y="60">-- km/h</text>
 
       <!-- Separator line -->
-      <line class="weather-separator" x1="0" y1="63" x2="204" y2="63"/>
+      <line class="weather-separator" x1="0" y1="69" x2="204" y2="69"/>
 
       <!-- Forecast 1: icon + day + temp inline -->
-      <text id="fc1-icon" class="weather-fc-icon" x="0"  y="79">--</text>
-      <text id="fc1-day"  class="weather-fc-day"  x="22" y="79">---</text>
-      <text id="fc1-temp" class="weather-fc-temp" x="90" y="79">--</text>
+      <text id="fc1-icon" class="weather-fc-icon" x="0"  y="87">--</text>
+      <text id="fc1-day"  class="weather-fc-day"  x="26" y="87">---</text>
+      <text id="fc1-temp" class="weather-fc-temp" x="100" y="87">--</text>
 
       <!-- Forecast 2: icon + day + temp inline -->
-      <text id="fc2-icon" class="weather-fc-icon" x="0"  y="97">--</text>
-      <text id="fc2-day"  class="weather-fc-day"  x="22" y="97">---</text>
-      <text id="fc2-temp" class="weather-fc-temp" x="90" y="97">--</text>
+      <text id="fc2-icon" class="weather-fc-icon" x="0"  y="108">--</text>
+      <text id="fc2-day"  class="weather-fc-day"  x="26" y="108">---</text>
+      <text id="fc2-temp" class="weather-fc-temp" x="100" y="108">--</text>
     </g>
 
   </svg>

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -79,7 +79,7 @@
     <!-- ═══ WEATHER PANEL (top-right, single column) ═══ -->
     <g id="weather-panel" transform="translate(548, -38)">
       <!-- Current weather: icon + temp on one line, wind below -->
-      <text id="weather-icon" class="weather-icon" x="14" y="42" text-anchor="middle">--</text>
+      <text id="weather-icon" class="weather-icon" x="14" y="42" text-anchor="middle" font-family="Climacons-Font">--</text>
       <text id="weather-temp" class="weather-temp" x="32" y="42">--°</text>
       <text id="weather-wind" class="weather-wind" x="14" y="60">-- km/h</text>
 
@@ -87,12 +87,12 @@
       <line class="weather-separator" x1="0" y1="69" x2="204" y2="69"/>
 
       <!-- Forecast 1: icon + day + temp inline -->
-      <text id="fc1-icon" class="weather-fc-icon" x="0"  y="87">--</text>
+      <text id="fc1-icon" class="weather-fc-icon" x="0"  y="87" font-family="Climacons-Font">--</text>
       <text id="fc1-day"  class="weather-fc-day"  x="26" y="87">---</text>
       <text id="fc1-temp" class="weather-fc-temp" x="100" y="87">--</text>
 
       <!-- Forecast 2: icon + day + temp inline -->
-      <text id="fc2-icon" class="weather-fc-icon" x="0"  y="108">--</text>
+      <text id="fc2-icon" class="weather-fc-icon" x="0"  y="108" font-family="Climacons-Font">--</text>
       <text id="fc2-day"  class="weather-fc-day"  x="26" y="108">---</text>
       <text id="fc2-temp" class="weather-fc-temp" x="100" y="108">--</text>
     </g>

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -80,8 +80,8 @@
     <g id="weather-panel" transform="translate(548, -38)">
       <!-- Current weather: large icon spanning both rows, temp + wind stacked to the right -->
       <text id="weather-icon" class="weather-icon" x="22" y="60" text-anchor="middle" font-family="Climacons-Font">--</text>
-      <text id="weather-temp" class="weather-temp" x="48" y="42">--°</text>
-      <text id="weather-wind" class="weather-wind" x="48" y="60">-- km/h</text>
+      <text id="weather-temp" class="weather-temp" x="58" y="42">--°</text>
+      <text id="weather-wind" class="weather-wind" x="58" y="60">-- km/h</text>
 
       <!-- Separator line -->
       <line class="weather-separator" x1="0" y1="69" x2="204" y2="69"/>

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -78,19 +78,19 @@
 
     <!-- ═══ WEATHER PANEL (top-right) ═══ -->
     <g id="weather-panel">
-      <!-- Current weather: icon + temperature -->
-      <text id="weather-icon"
-            class="weather-icon"
-            x="471" y="44"
-            text-anchor="middle">--</text>
-      <text id="weather-temp"
-            class="weather-temp"
-            x="497" y="44">--°</text>
-
-      <!-- Wind speed -->
-      <text id="weather-wind"
-            class="weather-wind"
-            x="497" y="60">-- km/h</text>
+      <!-- Current weather: icon + temperature + wind -->
+      <g id="current-weather" transform="translate(455, 0)">
+        <text id="weather-icon"
+              class="weather-icon"
+              x="16" y="44"
+              text-anchor="middle">--</text>
+        <text id="weather-temp"
+              class="weather-temp"
+              x="42" y="44">--°</text>
+        <text id="weather-wind"
+              class="weather-wind"
+              x="42" y="60">-- km/h</text>
+      </g>
 
       <!-- Separator line -->
       <line class="weather-separator" x1="455" y1="68" x2="752" y2="68"/>

--- a/widgets/energyflow/energyflow.html
+++ b/widgets/energyflow/energyflow.html
@@ -77,7 +77,7 @@
     </g>
 
     <!-- ═══ WEATHER PANEL (top-right, single column) ═══ -->
-    <g id="weather-panel" transform="translate(548, -22)">
+    <g id="weather-panel" transform="translate(548, -38)">
       <!-- Current weather: icon + temp on one line, wind below -->
       <text id="weather-icon" class="weather-icon" x="14" y="42" text-anchor="middle">--</text>
       <text id="weather-temp" class="weather-temp" x="32" y="42">--°</text>

--- a/widgets/energyflow/energyflow.scss
+++ b/widgets/energyflow/energyflow.scss
@@ -88,4 +88,45 @@
     font-size: 10px;
     opacity: 0.5;
   }
+
+  // ─── Weather panel (top-right) ────────────────────────────
+  .weather-icon {
+    fill: rgba(255, 255, 255, 0.95);
+    font-size: 22px;
+  }
+
+  .weather-temp {
+    fill: #ffffff;
+    font-size: 20px;
+    font-weight: 600;
+  }
+
+  .weather-wind {
+    fill: rgba(255, 255, 255, 0.55);
+    font-size: 12px;
+    font-weight: 300;
+  }
+
+  .weather-separator {
+    stroke: rgba(255, 255, 255, 0.15);
+    stroke-width: 1;
+  }
+
+  .weather-fc-day {
+    fill: rgba(255, 255, 255, 0.55);
+    font-size: 11px;
+    font-weight: 300;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .weather-fc-icon {
+    fill: rgba(255, 255, 255, 0.9);
+    font-size: 17px;
+  }
+
+  .weather-fc-temp {
+    fill: rgba(255, 255, 255, 0.75);
+    font-size: 11px;
+  }
 }

--- a/widgets/energyflow/energyflow.scss
+++ b/widgets/energyflow/energyflow.scss
@@ -92,18 +92,18 @@
   // ─── Weather panel (top-right) ────────────────────────────
   .weather-icon {
     fill: rgba(255, 255, 255, 0.95);
-    font-size: 22px;
+    font-size: 16px;
   }
 
   .weather-temp {
     fill: #ffffff;
-    font-size: 20px;
+    font-size: 15px;
     font-weight: 600;
   }
 
   .weather-wind {
     fill: rgba(255, 255, 255, 0.55);
-    font-size: 12px;
+    font-size: 10px;
     font-weight: 300;
   }
 
@@ -114,7 +114,7 @@
 
   .weather-fc-day {
     fill: rgba(255, 255, 255, 0.55);
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 300;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -122,11 +122,11 @@
 
   .weather-fc-icon {
     fill: rgba(255, 255, 255, 0.9);
-    font-size: 17px;
+    font-size: 13px;
   }
 
   .weather-fc-temp {
     fill: rgba(255, 255, 255, 0.75);
-    font-size: 11px;
+    font-size: 10px;
   }
 }

--- a/widgets/energyflow/energyflow.scss
+++ b/widgets/energyflow/energyflow.scss
@@ -92,7 +92,7 @@
   // ─── Weather panel (top-right) ────────────────────────────
   .weather-icon {
     fill: rgba(255, 255, 255, 0.95);
-    font-size: 44px;
+    font-size: 52px;
     font-family: 'Climacons-Font';
   }
 

--- a/widgets/energyflow/energyflow.scss
+++ b/widgets/energyflow/energyflow.scss
@@ -92,7 +92,7 @@
   // ─── Weather panel (top-right) ────────────────────────────
   .weather-icon {
     fill: rgba(255, 255, 255, 0.95);
-    font-size: 26px;
+    font-size: 44px;
     font-family: 'Climacons-Font';
   }
 

--- a/widgets/energyflow/energyflow.scss
+++ b/widgets/energyflow/energyflow.scss
@@ -93,6 +93,7 @@
   .weather-icon {
     fill: rgba(255, 255, 255, 0.95);
     font-size: 26px;
+    font-family: 'Climacons-Font';
   }
 
   .weather-temp {
@@ -123,6 +124,7 @@
   .weather-fc-icon {
     fill: rgba(255, 255, 255, 0.9);
     font-size: 20px;
+    font-family: 'Climacons-Font';
   }
 
   .weather-fc-temp {

--- a/widgets/energyflow/energyflow.scss
+++ b/widgets/energyflow/energyflow.scss
@@ -92,18 +92,18 @@
   // ─── Weather panel (top-right) ────────────────────────────
   .weather-icon {
     fill: rgba(255, 255, 255, 0.95);
-    font-size: 16px;
+    font-size: 22px;
   }
 
   .weather-temp {
     fill: #ffffff;
-    font-size: 15px;
+    font-size: 20px;
     font-weight: 600;
   }
 
   .weather-wind {
     fill: rgba(255, 255, 255, 0.55);
-    font-size: 10px;
+    font-size: 12px;
     font-weight: 300;
   }
 
@@ -114,7 +114,7 @@
 
   .weather-fc-day {
     fill: rgba(255, 255, 255, 0.55);
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 300;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -122,11 +122,11 @@
 
   .weather-fc-icon {
     fill: rgba(255, 255, 255, 0.9);
-    font-size: 13px;
+    font-size: 17px;
   }
 
   .weather-fc-temp {
     fill: rgba(255, 255, 255, 0.75);
-    font-size: 10px;
+    font-size: 11px;
   }
 }

--- a/widgets/energyflow/energyflow.scss
+++ b/widgets/energyflow/energyflow.scss
@@ -92,18 +92,18 @@
   // ─── Weather panel (top-right) ────────────────────────────
   .weather-icon {
     fill: rgba(255, 255, 255, 0.95);
-    font-size: 22px;
+    font-size: 26px;
   }
 
   .weather-temp {
     fill: #ffffff;
-    font-size: 20px;
+    font-size: 24px;
     font-weight: 600;
   }
 
   .weather-wind {
     fill: rgba(255, 255, 255, 0.55);
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 300;
   }
 
@@ -114,7 +114,7 @@
 
   .weather-fc-day {
     fill: rgba(255, 255, 255, 0.55);
-    font-size: 11px;
+    font-size: 13px;
     font-weight: 300;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -122,11 +122,11 @@
 
   .weather-fc-icon {
     fill: rgba(255, 255, 255, 0.9);
-    font-size: 17px;
+    font-size: 20px;
   }
 
   .weather-fc-temp {
     fill: rgba(255, 255, 255, 0.75);
-    font-size: 11px;
+    font-size: 13px;
   }
 }


### PR DESCRIPTION
## Summary

- Adds a weather panel (top-right) to the energyflow SVG dashboard showing current temperature, weather icon, wind speed, and 2-day forecast
- Uses Climacons-Font (same as the existing weather widget) for weather icons
- Subscribes to the `weather_temperature` SSE event from the constructor so it's included in Smashing's SSE filter
- Also adds `wind_speed` as a separate field to the `weather_temperature` event payload in `jobs/weather.rb`

## Key technical decisions

- **Constructor registration**: `Dashing.widgets['weather_temperature']` must be populated in the widget constructor — `ready:` fires after the SSE URL is already built from `Object.keys(Dashing.widgets)`
- **Event routing**: `onData` checks `data.id` to distinguish energyflow vs. weather events
- **Font rendering in SVG**: `font-family` must be set via CSS class (not SVG presentation attribute), otherwise Smashing's global stylesheet overrides it

## Test plan

- [x] Weather icon, temperature, and wind speed appear in the top-right of the energyflow dashboard
- [x] 2-day forecast (icon + day + temp range) is shown below the separator line
- [x] Energy flow data (nodes, animated paths) continues to work normally
- [x] Weather icons match those shown in the weather widget on p2

🤖 Generated with [Claude Code](https://claude.com/claude-code)